### PR TITLE
ci: add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` — deploys the repo's static files to GitHub Pages on every push to `main`

## One-time setup required

In **Settings → Pages**, set the source to **GitHub Actions** (not a branch). The workflow won't work until that's done.

## How it works

Uses the official GitHub Pages Action stack:
1. `configure-pages` — validates Pages is enabled
2. `upload-pages-artifact` — bundles the repo root as the Pages artifact
3. `deploy-pages` — pushes to Pages and outputs the live URL

The `concurrency: group: pages` setting ensures parallel deploys cancel the older one rather than racing.

## Test plan

- [ ] Set Pages source to "GitHub Actions" in repo settings
- [ ] Merge this PR and confirm the Actions tab shows a successful deploy run
- [ ] Visit the Pages URL and confirm the landing page and `/cli-merge/` both load

https://claude.ai/code/session_014SCaDsCVpydkAuVeLQMVVD

---
_Generated by [Claude Code](https://claude.ai/code/session_014SCaDsCVpydkAuVeLQMVVD)_