### PR TITLE
fix: prevent spurious sections from dump-all profile/rateprofile headers

### DIFF
--- a/cli-merge/src/parser.js
+++ b/cli-merge/src/parser.js
@@ -89,13 +89,18 @@ export function parseCLI(text) {
       const name = commentMatch[1].trim();
       const nameLower = name.toLowerCase();
 
-      // "# profile" / "# rateprofile" sub-header stays inside its parent section
-      if (
-        current &&
-        ((current.id.startsWith("profile_") && nameLower === "profile") ||
-          (current.id.startsWith("rateprofile_") && nameLower === "rateprofile"))
-      ) {
-        current.lines.push(line);
+      // "# profile" / "# rateprofile" are sub-headers, never section openers.
+      // In diff-all format they appear after the profile N command (already inside
+      // the section). In dump-all format they appear before it as structural markers
+      // — discard those so no spurious section is created.
+      if (nameLower === "profile" || nameLower === "rateprofile") {
+        if (
+          current &&
+          ((current.id.startsWith("profile_") && nameLower === "profile") ||
+            (current.id.startsWith("rateprofile_") && nameLower === "rateprofile"))
+        ) {
+          current.lines.push(line);
+        }
         continue;
       }
 

--- a/tests/cli-merge/output.test.ts
+++ b/tests/cli-merge/output.test.ts
@@ -230,7 +230,8 @@ Deno.test("buildOutput - rateprofile section includes rateprofile switch command
   ];
   const out = buildOutput(sections, { rateprofile_1: "b" }, {});
   assertEquals(out.includes("rateprofile 1"), true);
-  assertEquals(out.trim().indexOf("rateprofile 1") < out.indexOf("set roll_rc_rate"), true);
+  assertEquals(out.includes("set roll_rc_rate = 120"), true);
+  assertEquals(out.indexOf("rateprofile 1") < out.indexOf("set roll_rc_rate = 120"), true);
 });
 
 Deno.test("buildOutput - profile section includes profile switch command", () => {
@@ -245,5 +246,6 @@ Deno.test("buildOutput - profile section includes profile switch command", () =>
   ];
   const out = buildOutput(sections, { profile_1: "b" }, {});
   assertEquals(out.includes("profile 1"), true);
-  assertEquals(out.trim().indexOf("profile 1") < out.indexOf("set dterm_lpf1_dyn_min_hz"), true);
+  assertEquals(out.includes("set dterm_lpf1_dyn_min_hz = 80"), true);
+  assertEquals(out.indexOf("profile 1") < out.indexOf("set dterm_lpf1_dyn_min_hz = 80"), true);
 });

--- a/tests/cli-merge/output.test.ts
+++ b/tests/cli-merge/output.test.ts
@@ -217,3 +217,33 @@ Deno.test("buildOutput - defaults only-b section to B without explicit selection
   const out = buildOutput(sections, {}, {});
   assertEquals(out.includes("beacon RX_LOST"), true);
 });
+
+Deno.test("buildOutput - rateprofile section includes rateprofile switch command", () => {
+  const sections = [
+    {
+      id: "rateprofile_1",
+      title: "Rate Profile 1",
+      linesA: [],
+      linesB: ["rateprofile 1", "# rateprofile", "set roll_rc_rate = 120"],
+      status: "only-b",
+    },
+  ];
+  const out = buildOutput(sections, { rateprofile_1: "b" }, {});
+  assertEquals(out.includes("rateprofile 1"), true);
+  assertEquals(out.trim().indexOf("rateprofile 1") < out.indexOf("set roll_rc_rate"), true);
+});
+
+Deno.test("buildOutput - profile section includes profile switch command", () => {
+  const sections = [
+    {
+      id: "profile_1",
+      title: "Profile 1",
+      linesA: [],
+      linesB: ["profile 1", "# profile", "set dterm_lpf1_dyn_min_hz = 80"],
+      status: "only-b",
+    },
+  ];
+  const out = buildOutput(sections, { profile_1: "b" }, {});
+  assertEquals(out.includes("profile 1"), true);
+  assertEquals(out.trim().indexOf("profile 1") < out.indexOf("set dterm_lpf1_dyn_min_hz"), true);
+});

--- a/tests/cli-merge/parser.test.ts
+++ b/tests/cli-merge/parser.test.ts
@@ -120,6 +120,100 @@ Deno.test("parseCLI - no section has empty lines array", () => {
   }
 });
 
+// dump all format — top-level "# profile" / "# rateprofile" before the profile N command
+
+const DUMP_ALL_CLI =
+  `# Betaflight / STM32F745 (S745) 4.4.0 Nov  1 2022 / 01:00:00 (abc) MSP API: 1.45
+# start the command batch
+batch start
+
+# feature
+feature TELEMETRY
+
+# master
+set gyro_lpf1_static_hz = 0
+
+# profile
+profile 0
+
+# profile
+set dterm_lpf1_dyn_min_hz = 75
+
+profile 1
+
+# profile
+set dterm_lpf1_dyn_min_hz = 80
+
+# rateprofile
+rateprofile 0
+
+# rateprofile
+set roll_rc_rate = 100
+
+rateprofile 1
+
+# rateprofile
+set roll_rc_rate = 120
+
+# save configuration
+save`;
+
+Deno.test("parseCLI dump-all - no spurious 'profile' section", () => {
+  const sections = parseCLI(DUMP_ALL_CLI);
+  assertEquals(sections.some((s) => s.id === "profile"), false);
+});
+
+Deno.test("parseCLI dump-all - no spurious 'rateprofile' section", () => {
+  const sections = parseCLI(DUMP_ALL_CLI);
+  assertEquals(sections.some((s) => s.id === "rateprofile"), false);
+});
+
+Deno.test("parseCLI dump-all - extracts profile_0 with settings", () => {
+  const sections = parseCLI(DUMP_ALL_CLI);
+  const p0 = sections.find((s) => s.id === "profile_0");
+  assertExists(p0);
+  assertEquals(p0.lines.some((l) => l.trim() === "profile 0"), true);
+  assertEquals(p0.lines.some((l) => l.includes("set dterm_lpf1_dyn_min_hz = 75")), true);
+});
+
+Deno.test("parseCLI dump-all - extracts profile_1 with settings", () => {
+  const sections = parseCLI(DUMP_ALL_CLI);
+  const p1 = sections.find((s) => s.id === "profile_1");
+  assertExists(p1);
+  assertEquals(p1.lines.some((l) => l.trim() === "profile 1"), true);
+  assertEquals(p1.lines.some((l) => l.includes("set dterm_lpf1_dyn_min_hz = 80")), true);
+});
+
+Deno.test("parseCLI dump-all - extracts rateprofile_0 with settings", () => {
+  const sections = parseCLI(DUMP_ALL_CLI);
+  const rp0 = sections.find((s) => s.id === "rateprofile_0");
+  assertExists(rp0);
+  assertEquals(rp0.lines.some((l) => l.trim() === "rateprofile 0"), true);
+  assertEquals(rp0.lines.some((l) => l.includes("set roll_rc_rate = 100")), true);
+});
+
+Deno.test("parseCLI dump-all - extracts rateprofile_1 with settings", () => {
+  const sections = parseCLI(DUMP_ALL_CLI);
+  const rp1 = sections.find((s) => s.id === "rateprofile_1");
+  assertExists(rp1);
+  assertEquals(rp1.lines.some((l) => l.trim() === "rateprofile 1"), true);
+  assertEquals(rp1.lines.some((l) => l.includes("set roll_rc_rate = 120")), true);
+});
+
+Deno.test("parseCLI dump-all vs diff-all - profile_0 sections are structurally equivalent", () => {
+  const diffSections = parseCLI(MINIMAL_CLI);
+  const dumpSections = parseCLI(DUMP_ALL_CLI);
+  const diffP0 = diffSections.find((s) => s.id === "profile_0");
+  const dumpP0 = dumpSections.find((s) => s.id === "profile_0");
+  assertExists(diffP0);
+  assertExists(dumpP0);
+  // Both should have the profile switch command and the sub-header comment
+  assertEquals(diffP0.lines.some((l) => l.trim() === "profile 0"), true);
+  assertEquals(dumpP0.lines.some((l) => l.trim() === "profile 0"), true);
+  assertEquals(diffP0.lines.some((l) => l.trim() === "# profile"), true);
+  assertEquals(dumpP0.lines.some((l) => l.trim() === "# profile"), true);
+});
+
 // compareSections
 
 Deno.test("compareSections - identical input yields all 'same'", () => {


### PR DESCRIPTION
## Summary

- **Root cause**: In `dump all` format, Betaflight emits a top-level `# profile` / `# rateprofile` comment *before* the `profile N` / `rateprofile N` switch command. The old parser opened new sections for these comments, creating spurious `"profile"` / `"rateprofile"` sections alongside the correct `profile_0`, `rateprofile_1`, etc. sections.
- **Impact of the bug**: (1) comparing a dump-all dump against a diff-all dump produced misleading diffs; (2) `buildOutput` emitted a double `# profile` header from the spurious section; (3) the author was unsure whether selected rateprofile settings would be applied to the right slot (they were, but the extra section noise obscured it).
- **Fix**: `# profile` and `# rateprofile` comments now never open their own sections. When encountered *inside* the matching `profile_N` / `rateprofile_N` section (diff-all format) they're kept there as before. When encountered *before* the switch command (dump-all format) they're discarded — the FC ignores comments, and each profile section already includes its own sub-header comment.

Closes #8

## Test plan

- [ ] New parser tests cover dump-all format: no spurious `"profile"` or `"rateprofile"` sections created
- [ ] New parser tests verify `profile_0`/`profile_1`/`rateprofile_0`/`rateprofile_1` all contain their switch commands and settings in dump-all format
- [ ] New cross-format test: `profile_0` from diff-all and dump-all are structurally equivalent (both have the switch command and sub-header comment)
- [ ] New output tests verify `profile N` / `rateprofile N` switch command appears before settings when a section is selected
- [ ] All existing tests continue to pass

https://claude.ai/code/session_01QEpbhjaQmS4sY99dZamU9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEpbhjaQmS4sY99dZamU9u)_