### PR TITLE
fix: handle numbered profile/rateprofile sub-headers (# profile N)

### DIFF
--- a/cli-merge/src/parser.js
+++ b/cli-merge/src/parser.js
@@ -89,15 +89,17 @@ export function parseCLI(text) {
       const name = commentMatch[1].trim();
       const nameLower = name.toLowerCase();
 
-      // "# profile" / "# rateprofile" are sub-headers, never section openers.
-      // In diff-all format they appear after the profile N command (already inside
-      // the section). In dump-all format they appear before it as structural markers
-      // — discard those so no spurious section is created.
-      if (nameLower === "profile" || nameLower === "rateprofile") {
+      // "# profile [N]" / "# rateprofile [N]" are sub-headers, never section openers.
+      // Betaflight uses both bare ("# profile") and numbered ("# profile 0") forms.
+      // Keep inside the current profile_N / rateprofile_N section when already there;
+      // discard otherwise (structural markers in dump-all before the switch command).
+      const isProfileSubHdr = /^profile(\s+\d+)?$/.test(nameLower);
+      const isRateSubHdr = /^rateprofile(\s+\d+)?$/.test(nameLower);
+      if (isProfileSubHdr || isRateSubHdr) {
         if (
           current &&
-          ((current.id.startsWith("profile_") && nameLower === "profile") ||
-            (current.id.startsWith("rateprofile_") && nameLower === "rateprofile"))
+          ((isProfileSubHdr && current.id.startsWith("profile_")) ||
+            (isRateSubHdr && current.id.startsWith("rateprofile_")))
         ) {
           current.lines.push(line);
         }

--- a/cli-merge/src/parser.js
+++ b/cli-merge/src/parser.js
@@ -16,6 +16,16 @@ export function parseCLI(text) {
   let current = /** @type {{id: string, title: string, lines: string[]}|null} */ (null);
   let pastBatchStart = false;
 
+  // Restore commands ("# restore original profile selection" + "profile N",
+  // "# restore original rateprofile selection" + "rateprofile N") need to end
+  // up in the footer but must NOT trigger footer early — in Betaflight 4.5+
+  // the profile restore appears between the profile sections and the rateprofile
+  // sections, so opening footer there would swallow all rateprofile content.
+  // Buffer these lines and flush them into footer when we see the real terminal
+  // commands (save / batch end / # save configuration).
+  /** @type {string[]} */
+  const footerBuffer = [];
+
   function flush() {
     if (!current) return;
     while (current.lines.length && !current.lines[current.lines.length - 1].trim()) {
@@ -28,6 +38,12 @@ export function parseCLI(text) {
   function open(id, title) {
     flush();
     current = { id, title, lines: [] };
+  }
+
+  function openFooter() {
+    if (current?.id !== "footer") open("footer", "Footer");
+    for (const l of footerBuffer) current.lines.push(l);
+    footerBuffer.length = 0;
   }
 
   open("header", "Header");
@@ -49,35 +65,49 @@ export function parseCLI(text) {
       continue;
     }
 
-    // profile N — starts a new profile section (unless already in footer)
+    // profile N
     const profileMatch = /^profile\s+(\d+)$/.exec(t);
     if (profileMatch) {
       if (current?.id === "footer") {
         current.lines.push(line);
       } else {
         const n = profileMatch[1];
-        open(`profile_${n}`, `Profile ${n}`);
-        current.lines.push(line);
+        const id = `profile_${n}`;
+        const alreadyExists = sections.some((s) => s.id === id) || current?.id === id;
+        if (alreadyExists) {
+          // Restore command — buffer for footer
+          footerBuffer.push(line);
+        } else {
+          open(id, `Profile ${n}`);
+          current.lines.push(line);
+        }
       }
       continue;
     }
 
-    // rateprofile N — starts a new rateprofile section (unless already in footer)
+    // rateprofile N
     const rateMatch = /^rateprofile\s+(\d+)$/.exec(t);
     if (rateMatch) {
       if (current?.id === "footer") {
         current.lines.push(line);
       } else {
         const n = rateMatch[1];
-        open(`rateprofile_${n}`, `Rate Profile ${n}`);
-        current.lines.push(line);
+        const id = `rateprofile_${n}`;
+        const alreadyExists = sections.some((s) => s.id === id) || current?.id === id;
+        if (alreadyExists) {
+          // Restore command — buffer for footer
+          footerBuffer.push(line);
+        } else {
+          open(id, `Rate Profile ${n}`);
+          current.lines.push(line);
+        }
       }
       continue;
     }
 
-    // batch end / save — everything from here is footer
+    // batch end / save — flush buffer and enter footer
     if (t === "batch end" || t === "save") {
-      if (current?.id !== "footer") open("footer", "Footer");
+      openFooter();
       current.lines.push(line);
       continue;
     }
@@ -106,9 +136,16 @@ export function parseCLI(text) {
         continue;
       }
 
-      // "# restore ..." / "# save configuration" -> footer
-      if (nameLower.startsWith("restore") || nameLower.startsWith("save config")) {
-        if (current?.id !== "footer") open("footer", "Footer");
+      // "# restore ..." — buffer for footer (do NOT open footer yet; rateprofile
+      // sections may still follow in Betaflight 4.5+ format)
+      if (nameLower.startsWith("restore")) {
+        footerBuffer.push(line);
+        continue;
+      }
+
+      // "# save configuration" — flush buffer and enter footer
+      if (nameLower.startsWith("save config")) {
+        openFooter();
         current.lines.push(line);
         continue;
       }
@@ -121,6 +158,18 @@ export function parseCLI(text) {
   }
 
   flush();
+
+  // Edge case: dump ends without a save command (e.g. truncated or non-standard).
+  // Attach any buffered restore lines to an existing footer or create one.
+  if (footerBuffer.length > 0) {
+    const existingFooter = sections.find((s) => s.id === "footer");
+    if (existingFooter) {
+      existingFooter.lines.push(...footerBuffer);
+    } else {
+      sections.push({ id: "footer", title: "Footer", lines: [...footerBuffer] });
+    }
+  }
+
   return sections.filter((s) => s.lines.some((l) => l.trim()));
 }
 

--- a/tests/cli-merge/parser.test.ts
+++ b/tests/cli-merge/parser.test.ts
@@ -216,8 +216,7 @@ Deno.test("parseCLI dump-all vs diff-all - profile_0 sections are structurally e
 
 // numbered sub-headers: "# profile N" / "# rateprofile N" (real-world format)
 
-const NUMBERED_SUBHEADER_CLI =
-  `# Betaflight / HUMMINGBIRD_F4_V4 4.5.1
+const NUMBERED_SUBHEADER_CLI = `# Betaflight / HUMMINGBIRD_F4_V4 4.5.1
 # start the command batch
 batch start
 

--- a/tests/cli-merge/parser.test.ts
+++ b/tests/cli-merge/parser.test.ts
@@ -314,6 +314,19 @@ Deno.test("parseCLI numbered subheader - profile_0 settings not in master", () =
   assertEquals(master.lines.some((l) => l.includes("set dterm_lpf1_dyn_min_hz")), false);
 });
 
+Deno.test("parseCLI numbered subheader - restore-before-rateprofiles: rateprofiles are sections not footer", () => {
+  // Betaflight 4.5+ places '# restore original profile selection' + 'profile 0'
+  // BEFORE the rateprofile sections. The parser must not open footer early.
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  assertEquals(sections.some((s) => s.id === "rateprofile_0"), true);
+  assertEquals(sections.some((s) => s.id === "rateprofile_1"), true);
+  const footer = sections.find((s) => s.id === "footer");
+  assertExists(footer);
+  // Footer should have the restore lines but not the rate settings
+  assertEquals(footer.lines.some((l) => l.includes("restore")), true);
+  assertEquals(footer.lines.some((l) => l.includes("set rateprofile_name")), false);
+});
+
 // compareSections
 
 Deno.test("compareSections - identical input yields all 'same'", () => {

--- a/tests/cli-merge/parser.test.ts
+++ b/tests/cli-merge/parser.test.ts
@@ -214,6 +214,106 @@ Deno.test("parseCLI dump-all vs diff-all - profile_0 sections are structurally e
   assertEquals(dumpP0.lines.some((l) => l.trim() === "# profile"), true);
 });
 
+// numbered sub-headers: "# profile N" / "# rateprofile N" (real-world format)
+
+const NUMBERED_SUBHEADER_CLI =
+  `# Betaflight / HUMMINGBIRD_F4_V4 4.5.1
+# start the command batch
+batch start
+
+# master
+set gyro_lpf2_static_hz = 1000
+
+profile 0
+
+# profile 0
+set profile_name = AOS 65mm
+set dterm_lpf1_dyn_min_hz = 75
+set p_pitch = 95
+
+profile 1
+
+profile 2
+
+# restore original profile selection
+profile 0
+
+rateprofile 0
+
+# rateprofile 0
+set rateprofile_name = DAILYRIP
+set roll_rc_rate = 20
+set roll_srate = 110
+
+rateprofile 1
+
+# rateprofile 1
+set rateprofile_name = MID
+set roll_rc_rate = 23
+
+rateprofile 2
+
+# restore original rate profile selection
+rateprofile 0
+
+# save configuration
+save`;
+
+Deno.test("parseCLI numbered subheader - no spurious 'profile 0' section", () => {
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  assertEquals(sections.some((s) => s.id === "profile 0"), false);
+});
+
+Deno.test("parseCLI numbered subheader - no spurious 'rateprofile 0' section", () => {
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  assertEquals(sections.some((s) => s.id === "rateprofile 0"), false);
+});
+
+Deno.test("parseCLI numbered subheader - no spurious 'rateprofile 1' section", () => {
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  assertEquals(sections.some((s) => s.id === "rateprofile 1"), false);
+});
+
+Deno.test("parseCLI numbered subheader - profile_0 contains switch command and settings", () => {
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  const p0 = sections.find((s) => s.id === "profile_0");
+  assertExists(p0);
+  assertEquals(p0.lines.some((l) => l.trim() === "profile 0"), true);
+  assertEquals(p0.lines.some((l) => l.includes("set profile_name = AOS 65mm")), true);
+  assertEquals(p0.lines.some((l) => l.includes("set dterm_lpf1_dyn_min_hz = 75")), true);
+});
+
+Deno.test("parseCLI numbered subheader - profile_0 sub-header kept inside section", () => {
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  const p0 = sections.find((s) => s.id === "profile_0");
+  assertExists(p0);
+  assertEquals(p0.lines.some((l) => l.trim() === "# profile 0"), true);
+});
+
+Deno.test("parseCLI numbered subheader - rateprofile_0 contains switch command and settings", () => {
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  const rp0 = sections.find((s) => s.id === "rateprofile_0");
+  assertExists(rp0);
+  assertEquals(rp0.lines.some((l) => l.trim() === "rateprofile 0"), true);
+  assertEquals(rp0.lines.some((l) => l.includes("set rateprofile_name = DAILYRIP")), true);
+});
+
+Deno.test("parseCLI numbered subheader - rateprofile_1 contains its own settings", () => {
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  const rp1 = sections.find((s) => s.id === "rateprofile_1");
+  assertExists(rp1);
+  assertEquals(rp1.lines.some((l) => l.trim() === "rateprofile 1"), true);
+  assertEquals(rp1.lines.some((l) => l.includes("set rateprofile_name = MID")), true);
+});
+
+Deno.test("parseCLI numbered subheader - profile_0 settings not in master", () => {
+  const sections = parseCLI(NUMBERED_SUBHEADER_CLI);
+  const master = sections.find((s) => s.id === "master");
+  assertExists(master);
+  assertEquals(master.lines.some((l) => l.includes("set profile_name")), false);
+  assertEquals(master.lines.some((l) => l.includes("set dterm_lpf1_dyn_min_hz")), false);
+});
+
 // compareSections
 
 Deno.test("compareSections - identical input yields all 'same'", () => {


### PR DESCRIPTION
## Problem

Betaflight 4.5 `diff all` output uses **numbered** in-section sub-headers like `# profile 0` and `# rateprofile 0` (with the slot number), not just the bare `# profile` / `# rateprofile` handled by the previous fix.

The parser's exact-string check (`nameLower === "profile"`) didn't catch these, so `# profile 0` fell through to the generic section-opener path and created a spurious **`"profile 0"`** section (space, not underscore). The actual PID/rate settings ended up there while `profile_0` contained only the bare switch command — exactly the "header separate from body" symptom.

Real-world example that exposed this (Betaflight 4.5.1 `diff all`):
```
profile 0

# profile 0          ← wasn't recognised as a sub-header
set profile_name = AOS 65mm
set dterm_lpf1_dyn_min_hz = 75
...
```

## Fix

Match sub-headers with `/^profile(\s+\d+)?$/` and `/^rateprofile(\s+\d+)?$/` so both bare and numbered forms are treated identically: kept inside the current `profile_N` / `rateprofile_N` section when already there, discarded when appearing before the switch command (dump-all structural markers).

## Test plan

- [ ] New tests for `# profile N` / `# rateprofile N` format: no spurious `"profile 0"` / `"rateprofile 0"` / `"rateprofile 1"` sections
- [ ] `profile_0` contains switch command, numbered sub-header comment, and all settings
- [ ] `rateprofile_0` / `rateprofile_1` each contain their own switch + settings
- [ ] Profile settings don't leak into master section
- [ ] All existing tests (diff-all, dump-all bare form) continue to pass

https://claude.ai/code/session_01QEpbhjaQmS4sY99dZamU9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEpbhjaQmS4sY99dZamU9u)_