### PR TITLE
feat: OSD section, footer-last ordering, git SHA version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Inject git SHA into HTML
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          find . -name "*.html" -not -path "./.git/*" \
+            -exec sed -i "s/__GIT_SHA__/$SHORT_SHA/g" {} +
+
       - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3

--- a/cli-merge/index.html
+++ b/cli-merge/index.html
@@ -284,6 +284,18 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
 .out-head { margin-bottom: .6rem; }
 .out-hint { font-size: .75rem; color: var(--muted); margin-top: .3rem; }
 
+/* ── Page footer ── */
+.page-footer {
+  text-align: center;
+  padding: 1.5rem;
+  font-size: .72rem;
+  color: var(--muted);
+  border-top: 1px solid var(--border);
+  margin-top: 1rem;
+}
+.page-footer a { color: inherit; text-decoration: none; }
+.page-footer a:hover { color: var(--text); }
+
 /* ── Toast ── */
 .toast {
   position: fixed;
@@ -380,6 +392,10 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
 </div>
 
 <div class="toast" id="toast"></div>
+
+<footer class="page-footer">
+  fpv-tools · <a href="https://github.com/cori/fpv-tools/commit/__GIT_SHA__">__GIT_SHA__</a>
+</footer>
 
 <script type="module">
 import { parseCLI, compareSections } from "./src/parser.js";

--- a/cli-merge/index.html
+++ b/cli-merge/index.html
@@ -394,7 +394,7 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
 <div class="toast" id="toast"></div>
 
 <footer class="page-footer">
-  fpv-tools · <a href="https://github.com/cori/fpv-tools/commit/__GIT_SHA__">__GIT_SHA__</a>
+  fpv-tools · <a href="https://github.com/cori/fpv-tools/commit/__GIT_SHA__" aria-label="View deployed commit __GIT_SHA__ on GitHub">__GIT_SHA__</a>
 </footer>
 
 <script type="module">

--- a/cli-merge/src/parser.js
+++ b/cli-merge/src/parser.js
@@ -170,6 +170,34 @@ export function parseCLI(text) {
     }
   }
 
+  // Extract osd_* settings from master (and any other non-structural section) into
+  // a dedicated "osd" section so users can skip or merge OSD layout separately from
+  // flight settings. An existing "# osd" section from newer Betaflight dumps is left
+  // alone; extracted lines are appended to it if present.
+  const osdLines = /** @type {string[]} */ ([]);
+  for (const sec of sections) {
+    if (sec.id === "header" || sec.id === "footer" || sec.id === "osd") continue;
+    const kept = [];
+    for (const line of sec.lines) {
+      if (/^set\s+osd_/.test(line.trim())) {
+        osdLines.push(line);
+      } else {
+        kept.push(line);
+      }
+    }
+    sec.lines = kept;
+  }
+  if (osdLines.length > 0) {
+    const existing = sections.find((s) => s.id === "osd");
+    if (existing) {
+      existing.lines.push(...osdLines);
+    } else {
+      const masterIdx = sections.findIndex((s) => s.id === "master");
+      const insertAt = masterIdx !== -1 ? masterIdx + 1 : sections.length;
+      sections.splice(insertAt, 0, { id: "osd", title: "OSD", lines: osdLines });
+    }
+  }
+
   return sections.filter((s) => s.lines.some((l) => l.trim()));
 }
 
@@ -198,6 +226,13 @@ export function compareSections(sectionsA, sectionsB) {
       allIds.push(s.id);
       seen.add(s.id);
     }
+  }
+
+  // Footer must always render last regardless of which dump introduced extra sections.
+  const footerIdx = allIds.indexOf("footer");
+  if (footerIdx !== -1 && footerIdx !== allIds.length - 1) {
+    allIds.splice(footerIdx, 1);
+    allIds.push("footer");
   }
 
   return allIds.map((id) => {

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ footer {
   </div>
 </main>
 
-<footer>fpv-tools · open source · <a href="https://github.com/cori/fpv-tools/commit/__GIT_SHA__" style="color:inherit;text-decoration:none">__GIT_SHA__</a></footer>
+<footer>fpv-tools · open source · <a href="https://github.com/cori/fpv-tools/commit/__GIT_SHA__" aria-label="View deployed commit __GIT_SHA__ on GitHub" style="color:inherit;text-decoration:none">__GIT_SHA__</a></footer>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ footer {
   </div>
 </main>
 
-<footer>fpv-tools · open source</footer>
+<footer>fpv-tools · open source · <a href="https://github.com/cori/fpv-tools/commit/__GIT_SHA__" style="color:inherit;text-decoration:none">__GIT_SHA__</a></footer>
 
 </body>
 </html>

--- a/tests/cli-merge/parser.test.ts
+++ b/tests/cli-merge/parser.test.ts
@@ -446,3 +446,64 @@ Deno.test("parseCLI - no osd section created when no osd_* settings present", ()
   const sections = parseCLI(MINIMAL_CLI);
   assertEquals(sections.some((s) => s.id === "osd"), false);
 });
+
+// Native # osd section (newer Betaflight dumps already have a dedicated section)
+
+const CLI_WITH_NATIVE_OSD = `# Betaflight / STM32F745 4.5.0
+# start the command batch
+batch start
+
+# master
+set gyro_lpf1_static_hz = 0
+
+# osd
+set osd_vbat_pos = 6177
+set osd_rssi_pos = 353
+
+# save configuration
+save`;
+
+const CLI_WITH_NATIVE_OSD_AND_MASTER_OSD = `# Betaflight / STM32F745 4.5.0
+# start the command batch
+batch start
+
+# master
+set gyro_lpf1_static_hz = 0
+set osd_craft_name_pos = 6151
+
+# osd
+set osd_vbat_pos = 6177
+
+# save configuration
+save`;
+
+Deno.test("parseCLI - native osd section is preserved as-is", () => {
+  const sections = parseCLI(CLI_WITH_NATIVE_OSD);
+  const osd = sections.find((s) => s.id === "osd");
+  assertExists(osd);
+  assertEquals(osd.lines.some((l) => l.includes("set osd_vbat_pos = 6177")), true);
+  assertEquals(osd.lines.some((l) => l.includes("set osd_rssi_pos = 353")), true);
+});
+
+Deno.test("parseCLI - native osd section: master stays clean", () => {
+  const sections = parseCLI(CLI_WITH_NATIVE_OSD);
+  const master = sections.find((s) => s.id === "master");
+  assertExists(master);
+  assertEquals(master.lines.every((l) => !/^set\s+osd_/.test(l.trim())), true);
+});
+
+Deno.test("parseCLI - osd_* lines from master are merged into native osd section", () => {
+  const sections = parseCLI(CLI_WITH_NATIVE_OSD_AND_MASTER_OSD);
+  const osd = sections.find((s) => s.id === "osd");
+  assertExists(osd);
+  assertEquals(osd.lines.some((l) => l.includes("set osd_vbat_pos = 6177")), true);
+  assertEquals(osd.lines.some((l) => l.includes("set osd_craft_name_pos = 6151")), true);
+  assertEquals(sections.filter((s) => s.id === "osd").length, 1);
+});
+
+Deno.test("parseCLI - master has no osd_* after merge into native osd section", () => {
+  const sections = parseCLI(CLI_WITH_NATIVE_OSD_AND_MASTER_OSD);
+  const master = sections.find((s) => s.id === "master");
+  assertExists(master);
+  assertEquals(master.lines.every((l) => !/^set\s+osd_/.test(l.trim())), true);
+});

--- a/tests/cli-merge/parser.test.ts
+++ b/tests/cli-merge/parser.test.ts
@@ -385,3 +385,64 @@ Deno.test("compareSections - exposes both linesA and linesB for diff sections", 
   assertEquals(compared[0].linesA, ["feature TELEMETRY"]);
   assertEquals(compared[0].linesB, ["feature RX_PPM"]);
 });
+
+Deno.test("compareSections - footer is always last even when B has extra sections", () => {
+  const a = [
+    { id: "master", title: "master", lines: ["set x = 1"] },
+    { id: "footer", title: "Footer", lines: ["save"] },
+  ];
+  const b = [
+    { id: "master", title: "master", lines: ["set x = 1"] },
+    { id: "feature", title: "feature", lines: ["feature OSD"] },
+    { id: "footer", title: "Footer", lines: ["save"] },
+  ];
+  const compared = compareSections(a, b);
+  assertEquals(compared[compared.length - 1].id, "footer");
+});
+
+// OSD extraction
+
+const CLI_WITH_OSD_IN_MASTER = `# Betaflight / STM32F745 4.4.0
+# start the command batch
+batch start
+
+# master
+set gyro_lpf1_static_hz = 0
+set osd_vbat_pos = 6177
+set osd_rssi_pos = 353
+set gyro_lpf2_static_hz = 500
+set osd_craft_name_pos = 6151
+
+# save configuration
+save`;
+
+Deno.test("parseCLI - osd_* lines extracted from master into osd section", () => {
+  const sections = parseCLI(CLI_WITH_OSD_IN_MASTER);
+  const osd = sections.find((s) => s.id === "osd");
+  assertExists(osd);
+  assertEquals(osd.lines.some((l) => l.includes("set osd_vbat_pos = 6177")), true);
+  assertEquals(osd.lines.some((l) => l.includes("set osd_rssi_pos = 353")), true);
+  assertEquals(osd.lines.some((l) => l.includes("set osd_craft_name_pos = 6151")), true);
+});
+
+Deno.test("parseCLI - master section does not contain osd_* lines after extraction", () => {
+  const sections = parseCLI(CLI_WITH_OSD_IN_MASTER);
+  const master = sections.find((s) => s.id === "master");
+  assertExists(master);
+  assertEquals(master.lines.every((l) => !/^set\s+osd_/.test(l.trim())), true);
+  assertEquals(master.lines.some((l) => l.includes("set gyro_lpf1_static_hz")), true);
+});
+
+Deno.test("parseCLI - osd section appears immediately after master", () => {
+  const sections = parseCLI(CLI_WITH_OSD_IN_MASTER);
+  const masterIdx = sections.findIndex((s) => s.id === "master");
+  const osdIdx = sections.findIndex((s) => s.id === "osd");
+  assertExists(sections[masterIdx]);
+  assertExists(sections[osdIdx]);
+  assertEquals(osdIdx, masterIdx + 1);
+});
+
+Deno.test("parseCLI - no osd section created when no osd_* settings present", () => {
+  const sections = parseCLI(MINIMAL_CLI);
+  assertEquals(sections.some((s) => s.id === "osd"), false);
+});


### PR DESCRIPTION
## Summary

- **OSD section extraction** — `set osd_*` lines are extracted from `master` (and any other non-structural section) into a dedicated **OSD** section at parse time, inserted right after `master`. Users can now compare, skip, or merge OSD layout independently from PIDs and flight settings. If the dump already has a native `# osd` section (newer Betaflight), it's left alone.

- **Footer always last** — `compareSections` now moves `footer` to the end of the section ID list. Previously, B-only sections (feature, aux, etc. present in B but not A) got appended after `footer`, pushing the footer into the middle of the UI card list.

- **Git SHA in page footer** — Both `index.html` and `cli-merge/index.html` now show the deployed commit SHA in the page footer, linking to the commit on GitHub. The deploy workflow replaces the `__GIT_SHA__` placeholder with the real short SHA before uploading to Pages.

## Test plan

- [ ] `parseCLI` — `set osd_*` lines extracted from master into `osd` section
- [ ] `parseCLI` — master does not contain `osd_*` lines after extraction
- [ ] `parseCLI` — `osd` section appears immediately after `master`
- [ ] `parseCLI` — no `osd` section created when no `osd_*` settings present
- [ ] `compareSections` — footer is last even when B has extra sections
- [ ] All existing tests continue to pass

https://claude.ai/code/session_01QEpbhjaQmS4sY99dZamU9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEpbhjaQmS4sY99dZamU9u)_