### PR TITLE
Backport PR & commit hygiene guideline

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -4,6 +4,14 @@ This repository is a template for building using Claude Code. This guide establi
 
 We'll be working on the repo through GitHub issues; as soon as you've finished reading this file make sure you have the `gh` client installed and that you can access issues. You can install it with `apt-get install -y gh`.
 
+## Collaboration
+
+### Pull Requests & Commits
+
+- Do not include session URLs, agent names, or tool identifiers in PR bodies, commit messages, or code comments — keep those to chat only
+- PR descriptions: summary bullets + a test plan checklist is enough
+- Always reference the closing issue with `Resolves #X` (or `Closes #X`) in the PR body so GitHub auto-closes it on merge
+
 ## Development Philosophy and Methodology
 
 ### Red-Green-Refactor (TDD)


### PR DESCRIPTION
## Summary

Backport from `cori/claude-code-base`: adds a **Collaboration / Pull Requests & Commits** section establishing shared conventions:
- No session URLs, agent names, or tool identifiers in PR bodies, commit messages, or code comments
- PR descriptions: summary bullets + test plan checklist
- Reference closing issue with `Resolves #X`

## Test plan
- [ ] Verify the new section appears in claude.md before the first `##` content section