### PR TITLE
Backport session-start hook and settings

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install gh CLI if missing
+if ! command -v gh &>/dev/null; then
+  apt-get install -y gh 2>&1
+fi
+
+# Install repo skills into ~/.claude/skills/
+bash "${CLAUDE_PROJECT_DIR}/install-skills.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(apt-get install -y *)",
+      "Bash(gh *)",
+      "Bash(bash install-skills.sh)",
+      "Bash(deno *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- `.claude/hooks/session-start.sh`: installs `gh` and repo skills automatically at the start of every remote session
- `.claude/settings.json`: registers the hook; pre-approves `gh`, `apt-get`, `deno`, and `install-skills.sh` to avoid permission prompts

Backported from `cori/claude-code-base`.

## Test plan
- [ ] `CLAUDE_CODE_REMOTE=true CLAUDE_PROJECT_DIR=. bash .claude/hooks/session-start.sh` exits 0
- [ ] New remote session has `gh` available without manual install