### PR TITLE
Throttle limit, collapsible graphs, CLI file picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ Compare two Betaflight CLI dumps side-by-side and generate a merged output. Usef
 - Comparing tune changes across revisions
 - Extracting specific sections from full dumps
 
+Inputs accept pasted text, a file picker, or drag-and-drop from your desktop.
+
 ### 📈 Rate Profile Comparison
 **Path:** `./rate-profile/`
 
 Compare two Betaflight Actual Rates profiles with real-time visualization. Features:
 - **Dual profile editor** — adjust roll, pitch, yaw, throttle on two profiles simultaneously
+- **Throttle limit** — Off/Scale/Clip mode plus a 25-100% limit slider, matching Betaflight's `throttle_limit_*` settings
 - **Live graphs** — see rate curves and throttle response update instantly
+- **Collapsible graph panels** — hide individual graphs; the state is remembered between visits
 - **Overlay or side-by-side view** — choose how you compare
 - **Profile history** — save, name, and load profiles from browser localStorage
 - **CLI import/export** — paste Betaflight dumps to load settings; copy CLI commands back

--- a/cli-merge/index.html
+++ b/cli-merge/index.html
@@ -60,14 +60,46 @@ body {
 }
 @media (max-width: 700px) { .input-grid { grid-template-columns: 1fr; } }
 
+.input-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  margin-bottom: .35rem;
+}
+
 .input-label {
   display: flex;
   align-items: center;
   gap: .4rem;
   font-size: .8rem;
   font-weight: 600;
-  margin-bottom: .35rem;
 }
+
+.input-actions { display: flex; align-items: center; gap: .4rem; }
+.file-input { display: none; }
+
+.drop-zone { position: relative; }
+.drop-zone textarea { width: 100%; }
+
+.drop-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(224, 123, 57, .12);
+  border: 2px dashed var(--orange);
+  border-radius: 6px;
+  color: var(--orange);
+  font-size: .85rem;
+  font-weight: 600;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .12s;
+}
+
+.drop-zone.drag-over .drop-overlay { opacity: 1; }
 .dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
 .dot-a { background: var(--a); }
 .dot-b { background: var(--b); }
@@ -341,12 +373,30 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
   <!-- ── Step 1: Inputs ── -->
   <div class="input-grid">
     <div>
-      <div class="input-label"><span class="dot dot-a"></span>CLI A (base)</div>
-      <textarea id="cli-a" placeholder="Paste output of  diff all  or  dump all  here…"></textarea>
+      <div class="input-row">
+        <div class="input-label"><span class="dot dot-a"></span>CLI A (base)</div>
+        <div class="input-actions">
+          <button type="button" class="btn btn-ghost btn-sm" data-load-file="cli-a">📁 Load file</button>
+          <input type="file" class="file-input" data-target="cli-a" accept=".txt,.cli,.config,.log,text/plain">
+        </div>
+      </div>
+      <div class="drop-zone" data-drop-target="cli-a">
+        <textarea id="cli-a" placeholder="Paste output of  diff all  or  dump all  here — or drop a file"></textarea>
+        <div class="drop-overlay">Drop file to load</div>
+      </div>
     </div>
     <div>
-      <div class="input-label"><span class="dot dot-b"></span>CLI B (source)</div>
-      <textarea id="cli-b" placeholder="Paste output of  diff all  or  dump all  here…"></textarea>
+      <div class="input-row">
+        <div class="input-label"><span class="dot dot-b"></span>CLI B (source)</div>
+        <div class="input-actions">
+          <button type="button" class="btn btn-ghost btn-sm" data-load-file="cli-b">📁 Load file</button>
+          <input type="file" class="file-input" data-target="cli-b" accept=".txt,.cli,.config,.log,text/plain">
+        </div>
+      </div>
+      <div class="drop-zone" data-drop-target="cli-b">
+        <textarea id="cli-b" placeholder="Paste output of  diff all  or  dump all  here — or drop a file"></textarea>
+        <div class="drop-overlay">Drop file to load</div>
+      </div>
     </div>
   </div>
 
@@ -628,6 +678,58 @@ function refreshOutput() {
   const out = buildOutput(state.sections, state.selections, state.setSelections);
   document.getElementById("output-area").value = out;
 }
+
+// ── File loading (picker + drag-and-drop) ──────────────────────────────────
+
+async function loadFileIntoTextarea(file, targetId) {
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const ta = document.getElementById(targetId);
+    ta.value = text;
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+    toast(`Loaded ${file.name}`);
+  } catch (err) {
+    toast(`Could not read file: ${err.message ?? err}`);
+  }
+}
+
+document.querySelectorAll("[data-load-file]").forEach((btn) => {
+  const targetId = btn.dataset.loadFile;
+  const input = document.querySelector(`.file-input[data-target="${targetId}"]`);
+  if (!input) return;
+  btn.addEventListener("click", () => input.click());
+  input.addEventListener("change", () => {
+    const file = input.files?.[0];
+    loadFileIntoTextarea(file, targetId);
+    input.value = "";
+  });
+});
+
+document.querySelectorAll("[data-drop-target]").forEach((zone) => {
+  const targetId = zone.dataset.dropTarget;
+  zone.addEventListener("dragenter", (e) => {
+    if (!e.dataTransfer?.types.includes("Files")) return;
+    e.preventDefault();
+    zone.classList.add("drag-over");
+  });
+  zone.addEventListener("dragover", (e) => {
+    if (!e.dataTransfer?.types.includes("Files")) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  });
+  zone.addEventListener("dragleave", (e) => {
+    if (e.target === zone || !zone.contains(e.relatedTarget)) {
+      zone.classList.remove("drag-over");
+    }
+  });
+  zone.addEventListener("drop", (e) => {
+    if (!e.dataTransfer?.files?.length) return;
+    e.preventDefault();
+    zone.classList.remove("drag-over");
+    loadFileIntoTextarea(e.dataTransfer.files[0], targetId);
+  });
+});
 
 // ── Events ─────────────────────────────────────────────────────────────────
 

--- a/rate-profile/index.html
+++ b/rate-profile/index.html
@@ -61,25 +61,35 @@
 
             <!-- Graphs - Overlay Mode -->
             <div class="graphs-container" id="graphs-overlay">
-                <div class="graph-panel">
-                    <h2>Rate Curves</h2>
-                    <canvas id="rate-canvas" width="900" height="500"></canvas>
-                    <div class="graph-legend">
-                        <span class="legend-item"><span class="line-solid roll"></span> Roll</span>
-                        <span class="legend-item"><span class="line-solid pitch"></span> Pitch</span>
-                        <span class="legend-item"><span class="line-solid yaw"></span> Yaw</span>
-                        <span class="separator">|</span>
-                        <span class="legend-item"><span class="line-solid"></span> Profile A</span>
-                        <span class="legend-item"><span class="line-dashed"></span> Profile B</span>
+                <div class="graph-panel" data-collapse-key="overlay-rate">
+                    <button type="button" class="graph-panel-header" aria-expanded="true">
+                        <h2>Rate Curves</h2>
+                        <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                    </button>
+                    <div class="graph-panel-body">
+                        <canvas id="rate-canvas" width="900" height="500"></canvas>
+                        <div class="graph-legend">
+                            <span class="legend-item"><span class="line-solid roll"></span> Roll</span>
+                            <span class="legend-item"><span class="line-solid pitch"></span> Pitch</span>
+                            <span class="legend-item"><span class="line-solid yaw"></span> Yaw</span>
+                            <span class="separator">|</span>
+                            <span class="legend-item"><span class="line-solid"></span> Profile A</span>
+                            <span class="legend-item"><span class="line-dashed"></span> Profile B</span>
+                        </div>
                     </div>
                 </div>
 
-                <div class="graph-panel">
-                    <h2>Throttle Curves</h2>
-                    <canvas id="throttle-canvas" width="900" height="500"></canvas>
-                    <div class="graph-legend">
-                        <span class="legend-item"><span class="line-solid throttle"></span> Profile A</span>
-                        <span class="legend-item"><span class="line-dashed throttle"></span> Profile B</span>
+                <div class="graph-panel" data-collapse-key="overlay-throttle">
+                    <button type="button" class="graph-panel-header" aria-expanded="true">
+                        <h2>Throttle Curves</h2>
+                        <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                    </button>
+                    <div class="graph-panel-body">
+                        <canvas id="throttle-canvas" width="900" height="500"></canvas>
+                        <div class="graph-legend">
+                            <span class="legend-item"><span class="line-solid throttle"></span> Profile A</span>
+                            <span class="legend-item"><span class="line-dashed throttle"></span> Profile B</span>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -88,35 +98,55 @@
             <div class="graphs-container-sidebyside" id="graphs-sidebyside" style="display: none;">
                 <div class="profile-graphs">
                     <h2>Profile A</h2>
-                    <div class="graph-panel">
-                        <h3>Rate Curves</h3>
-                        <canvas id="rate-canvas-a" width="700" height="400"></canvas>
-                        <div class="graph-legend">
-                            <span class="legend-item"><span class="line-solid roll"></span> Roll</span>
-                            <span class="legend-item"><span class="line-solid pitch"></span> Pitch</span>
-                            <span class="legend-item"><span class="line-solid yaw"></span> Yaw</span>
+                    <div class="graph-panel" data-collapse-key="sbs-rate-a">
+                        <button type="button" class="graph-panel-header" aria-expanded="true">
+                            <h3>Rate Curves</h3>
+                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                        </button>
+                        <div class="graph-panel-body">
+                            <canvas id="rate-canvas-a" width="700" height="400"></canvas>
+                            <div class="graph-legend">
+                                <span class="legend-item"><span class="line-solid roll"></span> Roll</span>
+                                <span class="legend-item"><span class="line-solid pitch"></span> Pitch</span>
+                                <span class="legend-item"><span class="line-solid yaw"></span> Yaw</span>
+                            </div>
                         </div>
                     </div>
-                    <div class="graph-panel">
-                        <h3>Throttle Curve</h3>
-                        <canvas id="throttle-canvas-a" width="700" height="400"></canvas>
+                    <div class="graph-panel" data-collapse-key="sbs-throttle-a">
+                        <button type="button" class="graph-panel-header" aria-expanded="true">
+                            <h3>Throttle Curve</h3>
+                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                        </button>
+                        <div class="graph-panel-body">
+                            <canvas id="throttle-canvas-a" width="700" height="400"></canvas>
+                        </div>
                     </div>
                 </div>
 
                 <div class="profile-graphs">
                     <h2>Profile B</h2>
-                    <div class="graph-panel">
-                        <h3>Rate Curves</h3>
-                        <canvas id="rate-canvas-b" width="700" height="400"></canvas>
-                        <div class="graph-legend">
-                            <span class="legend-item"><span class="line-solid roll"></span> Roll</span>
-                            <span class="legend-item"><span class="line-solid pitch"></span> Pitch</span>
-                            <span class="legend-item"><span class="line-solid yaw"></span> Yaw</span>
+                    <div class="graph-panel" data-collapse-key="sbs-rate-b">
+                        <button type="button" class="graph-panel-header" aria-expanded="true">
+                            <h3>Rate Curves</h3>
+                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                        </button>
+                        <div class="graph-panel-body">
+                            <canvas id="rate-canvas-b" width="700" height="400"></canvas>
+                            <div class="graph-legend">
+                                <span class="legend-item"><span class="line-solid roll"></span> Roll</span>
+                                <span class="legend-item"><span class="line-solid pitch"></span> Pitch</span>
+                                <span class="legend-item"><span class="line-solid yaw"></span> Yaw</span>
+                            </div>
                         </div>
                     </div>
-                    <div class="graph-panel">
-                        <h3>Throttle Curve</h3>
-                        <canvas id="throttle-canvas-b" width="700" height="400"></canvas>
+                    <div class="graph-panel" data-collapse-key="sbs-throttle-b">
+                        <button type="button" class="graph-panel-header" aria-expanded="true">
+                            <h3>Throttle Curve</h3>
+                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                        </button>
+                        <div class="graph-panel-body">
+                            <canvas id="throttle-canvas-b" width="700" height="400"></canvas>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/rate-profile/index.html
+++ b/rate-profile/index.html
@@ -208,6 +208,19 @@
                             <input type="range" id="a-throttle-expo" min="0" max="100" value="0" step="1">
                             <span id="a-throttle-expo-value" class="value-display">0</span>
                         </div>
+                        <div class="control-item">
+                            <label for="a-throttle-limit-type">Limit Type:</label>
+                            <select id="a-throttle-limit-type" class="select-input">
+                                <option value="OFF">Off</option>
+                                <option value="SCALE">Scale</option>
+                                <option value="CLIP">Clip</option>
+                            </select>
+                        </div>
+                        <div class="control-item">
+                            <label for="a-throttle-limit-percent">Limit Percent (25-100):</label>
+                            <input type="range" id="a-throttle-limit-percent" min="25" max="100" value="100" step="1">
+                            <span id="a-throttle-limit-percent-value" class="value-display">100</span>
+                        </div>
                     </div>
                 </div>
 
@@ -311,6 +324,19 @@
                             <label for="b-throttle-expo">Expo (0-100):</label>
                             <input type="range" id="b-throttle-expo" min="0" max="100" value="0" step="1">
                             <span id="b-throttle-expo-value" class="value-display">0</span>
+                        </div>
+                        <div class="control-item">
+                            <label for="b-throttle-limit-type">Limit Type:</label>
+                            <select id="b-throttle-limit-type" class="select-input">
+                                <option value="OFF">Off</option>
+                                <option value="SCALE">Scale</option>
+                                <option value="CLIP">Clip</option>
+                            </select>
+                        </div>
+                        <div class="control-item">
+                            <label for="b-throttle-limit-percent">Limit Percent (25-100):</label>
+                            <input type="range" id="b-throttle-limit-percent" min="25" max="100" value="100" step="1">
+                            <span id="b-throttle-limit-percent-value" class="value-display">100</span>
                         </div>
                     </div>
                 </div>

--- a/rate-profile/index.html
+++ b/rate-profile/index.html
@@ -62,10 +62,12 @@
             <!-- Graphs - Overlay Mode -->
             <div class="graphs-container" id="graphs-overlay">
                 <div class="graph-panel" data-collapse-key="overlay-rate">
-                    <button type="button" class="graph-panel-header" aria-expanded="true">
-                        <h2>Rate Curves</h2>
-                        <span class="graph-panel-chevron" aria-hidden="true">▾</span>
-                    </button>
+                    <h2 class="graph-panel-heading">
+                        <button type="button" class="graph-panel-header" aria-expanded="true">
+                            <span>Rate Curves</span>
+                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                        </button>
+                    </h2>
                     <div class="graph-panel-body">
                         <canvas id="rate-canvas" width="900" height="500"></canvas>
                         <div class="graph-legend">
@@ -80,10 +82,12 @@
                 </div>
 
                 <div class="graph-panel" data-collapse-key="overlay-throttle">
-                    <button type="button" class="graph-panel-header" aria-expanded="true">
-                        <h2>Throttle Curves</h2>
-                        <span class="graph-panel-chevron" aria-hidden="true">▾</span>
-                    </button>
+                    <h2 class="graph-panel-heading">
+                        <button type="button" class="graph-panel-header" aria-expanded="true">
+                            <span>Throttle Curves</span>
+                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                        </button>
+                    </h2>
                     <div class="graph-panel-body">
                         <canvas id="throttle-canvas" width="900" height="500"></canvas>
                         <div class="graph-legend">
@@ -99,10 +103,12 @@
                 <div class="profile-graphs">
                     <h2>Profile A</h2>
                     <div class="graph-panel" data-collapse-key="sbs-rate-a">
-                        <button type="button" class="graph-panel-header" aria-expanded="true">
-                            <h3>Rate Curves</h3>
-                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
-                        </button>
+                        <h3 class="graph-panel-heading">
+                            <button type="button" class="graph-panel-header" aria-expanded="true">
+                                <span>Rate Curves</span>
+                                <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                            </button>
+                        </h3>
                         <div class="graph-panel-body">
                             <canvas id="rate-canvas-a" width="700" height="400"></canvas>
                             <div class="graph-legend">
@@ -113,10 +119,12 @@
                         </div>
                     </div>
                     <div class="graph-panel" data-collapse-key="sbs-throttle-a">
-                        <button type="button" class="graph-panel-header" aria-expanded="true">
-                            <h3>Throttle Curve</h3>
-                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
-                        </button>
+                        <h3 class="graph-panel-heading">
+                            <button type="button" class="graph-panel-header" aria-expanded="true">
+                                <span>Throttle Curve</span>
+                                <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                            </button>
+                        </h3>
                         <div class="graph-panel-body">
                             <canvas id="throttle-canvas-a" width="700" height="400"></canvas>
                         </div>
@@ -126,10 +134,12 @@
                 <div class="profile-graphs">
                     <h2>Profile B</h2>
                     <div class="graph-panel" data-collapse-key="sbs-rate-b">
-                        <button type="button" class="graph-panel-header" aria-expanded="true">
-                            <h3>Rate Curves</h3>
-                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
-                        </button>
+                        <h3 class="graph-panel-heading">
+                            <button type="button" class="graph-panel-header" aria-expanded="true">
+                                <span>Rate Curves</span>
+                                <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                            </button>
+                        </h3>
                         <div class="graph-panel-body">
                             <canvas id="rate-canvas-b" width="700" height="400"></canvas>
                             <div class="graph-legend">
@@ -140,10 +150,12 @@
                         </div>
                     </div>
                     <div class="graph-panel" data-collapse-key="sbs-throttle-b">
-                        <button type="button" class="graph-panel-header" aria-expanded="true">
-                            <h3>Throttle Curve</h3>
-                            <span class="graph-panel-chevron" aria-hidden="true">▾</span>
-                        </button>
+                        <h3 class="graph-panel-heading">
+                            <button type="button" class="graph-panel-header" aria-expanded="true">
+                                <span>Throttle Curve</span>
+                                <span class="graph-panel-chevron" aria-hidden="true">▾</span>
+                            </button>
+                        </h3>
                         <div class="graph-panel-body">
                             <canvas id="throttle-canvas-b" width="700" height="400"></canvas>
                         </div>

--- a/rate-profile/src/app.js
+++ b/rate-profile/src/app.js
@@ -58,7 +58,9 @@ class RateProfileComparison {
       },
       throttle: {
         mid: 50,
-        expo: 0
+        expo: 0,
+        limitType: 'OFF',
+        limitPercent: 100
       }
     };
   }
@@ -119,6 +121,21 @@ class RateProfileComparison {
         const value = parseInt(e.target.value);
         profileObj.throttle.expo = value;
         throttleExpoValue.textContent = value;
+        this.onProfileChange();
+      });
+
+      const throttleLimitTypeInput = document.getElementById(`${profile}-throttle-limit-type`);
+      throttleLimitTypeInput.addEventListener('change', (e) => {
+        profileObj.throttle.limitType = e.target.value;
+        this.onProfileChange();
+      });
+
+      const throttleLimitPercentInput = document.getElementById(`${profile}-throttle-limit-percent`);
+      const throttleLimitPercentValue = document.getElementById(`${profile}-throttle-limit-percent-value`);
+      throttleLimitPercentInput.addEventListener('input', (e) => {
+        const value = parseInt(e.target.value);
+        profileObj.throttle.limitPercent = value;
+        throttleLimitPercentValue.textContent = value;
         this.onProfileChange();
       });
     });
@@ -340,7 +357,9 @@ class RateProfileComparison {
         pitch_expo: (v) => profileObj.rates.pitch.expo = parseInt(v),
         yaw_expo: (v) => profileObj.rates.yaw.expo = parseInt(v),
         thr_mid: (v) => profileObj.throttle.mid = parseInt(v),
-        thr_expo: (v) => profileObj.throttle.expo = parseInt(v)
+        thr_expo: (v) => profileObj.throttle.expo = parseInt(v),
+        throttle_limit_type: (v) => profileObj.throttle.limitType = String(v).trim().toUpperCase(),
+        throttle_limit_percent: (v) => profileObj.throttle.limitPercent = parseInt(v)
       };
 
       let count = 0;
@@ -385,6 +404,10 @@ class RateProfileComparison {
     document.getElementById(`${profile}-throttle-mid-value`).textContent = profileObj.throttle.mid;
     document.getElementById(`${profile}-throttle-expo`).value = profileObj.throttle.expo;
     document.getElementById(`${profile}-throttle-expo-value`).textContent = profileObj.throttle.expo;
+    document.getElementById(`${profile}-throttle-limit-type`).value = profileObj.throttle.limitType ?? 'OFF';
+    const limitPercent = profileObj.throttle.limitPercent ?? 100;
+    document.getElementById(`${profile}-throttle-limit-percent`).value = limitPercent;
+    document.getElementById(`${profile}-throttle-limit-percent-value`).textContent = limitPercent;
   }
 
   async copyExport(profile) {

--- a/rate-profile/src/app.js
+++ b/rate-profile/src/app.js
@@ -37,6 +37,7 @@ class RateProfileComparison {
     this.initializeImportExport();
     this.initializeProfileActions();
     this.initializeHistory();
+    this.initializeGraphCollapse();
 
     // Check viewport width and update view mode controls
     this.checkViewportWidth();
@@ -291,6 +292,51 @@ class RateProfileComparison {
         this.renderHistory();
       }
     });
+  }
+
+  initializeGraphCollapse() {
+    this.collapseStorageKey = 'fpv-rate-graph-collapsed';
+    const stored = this.loadCollapsedState();
+
+    document.querySelectorAll('.graph-panel[data-collapse-key]').forEach(panel => {
+      const key = panel.dataset.collapseKey;
+      if (stored[key]) {
+        panel.classList.add('collapsed');
+      }
+      const header = panel.querySelector('.graph-panel-header');
+      if (!header) return;
+      header.setAttribute('aria-expanded', String(!panel.classList.contains('collapsed')));
+      header.addEventListener('click', () => {
+        const collapsed = panel.classList.toggle('collapsed');
+        header.setAttribute('aria-expanded', String(!collapsed));
+        this.saveCollapsedState(key, collapsed);
+        // Re-render so the canvas is correctly sized after expanding
+        if (!collapsed) this.updateGraphs();
+      });
+    });
+  }
+
+  loadCollapsedState() {
+    try {
+      const raw = localStorage.getItem(this.collapseStorageKey);
+      return raw ? JSON.parse(raw) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  saveCollapsedState(key, collapsed) {
+    try {
+      const state = this.loadCollapsedState();
+      if (collapsed) {
+        state[key] = true;
+      } else {
+        delete state[key];
+      }
+      localStorage.setItem(this.collapseStorageKey, JSON.stringify(state));
+    } catch {
+      // Ignore quota / privacy-mode errors
+    }
   }
 
   onProfileChange() {

--- a/rate-profile/src/app.js
+++ b/rate-profile/src/app.js
@@ -320,7 +320,12 @@ class RateProfileComparison {
   loadCollapsedState() {
     try {
       const raw = localStorage.getItem(this.collapseStorageKey);
-      return raw ? JSON.parse(raw) : {};
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed;
+      }
+      return {};
     } catch {
       return {};
     }

--- a/rate-profile/src/app.js
+++ b/rate-profile/src/app.js
@@ -1,6 +1,7 @@
 import { GraphRenderer } from './graph-renderer.js';
 import { ProfileManager } from './profile-manager.js';
 import { parseCLI, generateCLI } from './cli-parser.js';
+import { normalizeLimitPercent, normalizeLimitType } from './rate-calculator.js';
 
 /**
  * Main application controller
@@ -404,8 +405,8 @@ class RateProfileComparison {
         yaw_expo: (v) => profileObj.rates.yaw.expo = parseInt(v),
         thr_mid: (v) => profileObj.throttle.mid = parseInt(v),
         thr_expo: (v) => profileObj.throttle.expo = parseInt(v),
-        throttle_limit_type: (v) => profileObj.throttle.limitType = String(v).trim().toUpperCase(),
-        throttle_limit_percent: (v) => profileObj.throttle.limitPercent = parseInt(v)
+        throttle_limit_type: (v) => profileObj.throttle.limitType = normalizeLimitType(v),
+        throttle_limit_percent: (v) => profileObj.throttle.limitPercent = normalizeLimitPercent(v)
       };
 
       let count = 0;

--- a/rate-profile/src/cli-parser.js
+++ b/rate-profile/src/cli-parser.js
@@ -61,6 +61,8 @@ export function generateCLI(profile) {
     '# Throttle',
     `set thr_mid = ${profile.throttle.mid}`,
     `set thr_expo = ${profile.throttle.expo}`,
+    `set throttle_limit_type = ${profile.throttle.limitType ?? 'OFF'}`,
+    `set throttle_limit_percent = ${profile.throttle.limitPercent ?? 100}`,
     '',
     'save'
   );

--- a/rate-profile/src/cli-parser.js
+++ b/rate-profile/src/cli-parser.js
@@ -1,3 +1,5 @@
+import { normalizeLimitPercent, normalizeLimitType } from './rate-calculator.js';
+
 /**
  * Parse Betaflight CLI dump format
  * @param {string} text - CLI dump text
@@ -61,8 +63,8 @@ export function generateCLI(profile) {
     '# Throttle',
     `set thr_mid = ${profile.throttle.mid}`,
     `set thr_expo = ${profile.throttle.expo}`,
-    `set throttle_limit_type = ${profile.throttle.limitType ?? 'OFF'}`,
-    `set throttle_limit_percent = ${profile.throttle.limitPercent ?? 100}`,
+    `set throttle_limit_type = ${normalizeLimitType(profile.throttle.limitType)}`,
+    `set throttle_limit_percent = ${normalizeLimitPercent(profile.throttle.limitPercent)}`,
     '',
     'save'
   );

--- a/rate-profile/src/graph-renderer.js
+++ b/rate-profile/src/graph-renderer.js
@@ -233,7 +233,13 @@ export class GraphRenderer {
 
     for (let i = 0; i <= steps; i++) {
       const input = i / steps;
-      const throttleValue = calculateThrottle(input, throttle.mid, throttle.expo);
+      const throttleValue = calculateThrottle(
+        input,
+        throttle.mid,
+        throttle.expo,
+        throttle.limitType,
+        throttle.limitPercent,
+      );
 
       const x = this.padding + (width - 2 * this.padding) * input;
       const y = height - this.padding - (height - 2 * this.padding) * throttleValue;

--- a/rate-profile/src/rate-calculator.js
+++ b/rate-profile/src/rate-calculator.js
@@ -32,9 +32,11 @@ export function calculateActualRate(rcCommand, center, maxRate, expo) {
  * @param {number} input - Throttle stick input from 0 to 1
  * @param {number} midPoint - Mid point value (0-100)
  * @param {number} expo - Expo value (0-100)
+ * @param {string} [limitType='OFF'] - Throttle limit mode: 'OFF', 'SCALE', or 'CLIP'
+ * @param {number} [limitPercent=100] - Throttle limit percentage (25-100)
  * @returns {number} Throttle output from 0 to 1
  */
-export function calculateThrottle(input, midPoint, expo) {
+export function calculateThrottle(input, midPoint, expo, limitType = "OFF", limitPercent = 100) {
   const mid = midPoint / 100;
   const expoNorm = expo / 100;
 
@@ -49,6 +51,13 @@ export function calculateThrottle(input, midPoint, expo) {
   } else {
     // Scale 0.5-1.0 input to mid-1.0 output
     throttle = mid + (expof - 0.5) * 2 * (1 - mid);
+  }
+
+  const limit = limitPercent / 100;
+  if (limitType === "SCALE") {
+    throttle = throttle * limit;
+  } else if (limitType === "CLIP") {
+    throttle = Math.min(throttle, limit);
   }
 
   return throttle;

--- a/rate-profile/src/rate-calculator.js
+++ b/rate-profile/src/rate-calculator.js
@@ -28,6 +28,29 @@ export function calculateActualRate(rcCommand, center, maxRate, expo) {
 }
 
 /**
+ * Normalize a throttle limit type to one of OFF/SCALE/CLIP.
+ * Anything unrecognized (including null/undefined) becomes OFF.
+ * @param {unknown} value
+ * @returns {'OFF'|'SCALE'|'CLIP'}
+ */
+export function normalizeLimitType(value) {
+  const t = String(value ?? "").trim().toUpperCase();
+  return t === "SCALE" || t === "CLIP" ? t : "OFF";
+}
+
+/**
+ * Normalize a throttle limit percent. Non-finite values fall back to 100;
+ * valid numbers are clamped to 0..100.
+ * @param {unknown} value
+ * @returns {number}
+ */
+export function normalizeLimitPercent(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 100;
+  return Math.min(100, Math.max(0, n));
+}
+
+/**
  * Calculate throttle output with mid point and expo
  * @param {number} input - Throttle stick input from 0 to 1
  * @param {number} midPoint - Mid point value (0-100)
@@ -53,10 +76,11 @@ export function calculateThrottle(input, midPoint, expo, limitType = "OFF", limi
     throttle = mid + (expof - 0.5) * 2 * (1 - mid);
   }
 
-  const limit = limitPercent / 100;
-  if (limitType === "SCALE") {
+  const type = normalizeLimitType(limitType);
+  const limit = normalizeLimitPercent(limitPercent) / 100;
+  if (type === "SCALE") {
     throttle = throttle * limit;
-  } else if (limitType === "CLIP") {
+  } else if (type === "CLIP") {
     throttle = Math.min(throttle, limit);
   }
 

--- a/rate-profile/src/rate-calculator.js
+++ b/rate-profile/src/rate-calculator.js
@@ -40,14 +40,15 @@ export function normalizeLimitType(value) {
 
 /**
  * Normalize a throttle limit percent. Non-finite values fall back to 100;
- * valid numbers are clamped to 0..100.
+ * valid numbers are clamped to Betaflight's 25..100 range to match both the
+ * UI slider bounds and the firmware's documented limits.
  * @param {unknown} value
  * @returns {number}
  */
 export function normalizeLimitPercent(value) {
   const n = Number(value);
   if (!Number.isFinite(n)) return 100;
-  return Math.min(100, Math.max(0, n));
+  return Math.min(100, Math.max(25, n));
 }
 
 /**

--- a/rate-profile/styles.css
+++ b/rate-profile/styles.css
@@ -169,6 +169,11 @@ header h1 {
   cursor: pointer;
 }
 
+.graph-panel-header h2,
+.graph-panel-header h3 {
+  margin: 0;
+}
+
 .graph-panel-header:hover .graph-panel-chevron {
   color: var(--text-primary);
 }

--- a/rate-profile/styles.css
+++ b/rate-profile/styles.css
@@ -151,8 +151,44 @@ header h1 {
 
 .graph-panel h2 {
   font-size: 1.3rem;
-  margin-bottom: var(--spacing-md);
   color: var(--text-primary);
+}
+
+.graph-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0 0 var(--spacing-md) 0;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.graph-panel-header:hover .graph-panel-chevron {
+  color: var(--text-primary);
+}
+
+.graph-panel-chevron {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  transition: transform 0.15s ease;
+}
+
+.graph-panel.collapsed .graph-panel-chevron {
+  transform: rotate(-90deg);
+}
+
+.graph-panel.collapsed .graph-panel-body {
+  display: none;
+}
+
+.graph-panel.collapsed .graph-panel-header {
+  padding-bottom: 0;
 }
 
 .graph-panel canvas {
@@ -249,7 +285,6 @@ header h1 {
 
 .profile-graphs .graph-panel h3 {
   font-size: 1.1rem;
-  margin-bottom: var(--spacing-md);
   color: var(--text-primary);
 }
 

--- a/rate-profile/styles.css
+++ b/rate-profile/styles.css
@@ -420,6 +420,23 @@ header h1 {
   font-family: 'Courier New', monospace;
 }
 
+.select-input {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--bg-dark);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.select-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
 /* CLI Section */
 .cli-section {
   display: grid;

--- a/rate-profile/styles.css
+++ b/rate-profile/styles.css
@@ -154,6 +154,10 @@ header h1 {
   color: var(--text-primary);
 }
 
+.graph-panel-heading {
+  margin: 0;
+}
+
 .graph-panel-header {
   display: flex;
   align-items: center;
@@ -163,15 +167,10 @@ header h1 {
   background: transparent;
   border: none;
   padding: 0 0 var(--spacing-md) 0;
-  color: var(--text-primary);
+  color: inherit;
   font: inherit;
   text-align: left;
   cursor: pointer;
-}
-
-.graph-panel-header h2,
-.graph-panel-header h3 {
-  margin: 0;
 }
 
 .graph-panel-header:hover .graph-panel-chevron {

--- a/tests/rate-profile/rate-calculator.test.ts
+++ b/tests/rate-profile/rate-calculator.test.ts
@@ -1,5 +1,9 @@
 import { assertAlmostEquals, assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
-import { calculateThrottle } from "../../rate-profile/src/rate-calculator.js";
+import {
+  calculateThrottle,
+  normalizeLimitPercent,
+  normalizeLimitType,
+} from "../../rate-profile/src/rate-calculator.js";
 
 Deno.test("calculateThrottle - limit type OFF leaves output unchanged", () => {
   const base = calculateThrottle(1.0, 50, 0);
@@ -55,4 +59,76 @@ Deno.test("calculateThrottle - unknown limit type behaves as OFF", () => {
     base,
     1e-9,
   );
+});
+
+Deno.test("calculateThrottle - lowercase limit type is normalized", () => {
+  const base = calculateThrottle(1.0, 50, 0);
+  assertAlmostEquals(
+    calculateThrottle(1.0, 50, 0, "scale", 50),
+    base * 0.5,
+    1e-9,
+  );
+});
+
+Deno.test("calculateThrottle - NaN limit percent does not poison output", () => {
+  const base = calculateThrottle(1.0, 50, 0);
+  assertAlmostEquals(
+    calculateThrottle(1.0, 50, 0, "SCALE", NaN),
+    base,
+    1e-9,
+  );
+  assertAlmostEquals(
+    calculateThrottle(1.0, 50, 0, "CLIP", NaN),
+    base,
+    1e-9,
+  );
+});
+
+Deno.test("calculateThrottle - undefined limit type treated as OFF", () => {
+  const base = calculateThrottle(0.8, 50, 0);
+  assertAlmostEquals(
+    calculateThrottle(0.8, 50, 0, undefined, 50),
+    base,
+    1e-9,
+  );
+});
+
+Deno.test("normalizeLimitType - accepts canonical strings", () => {
+  assertEquals(normalizeLimitType("OFF"), "OFF");
+  assertEquals(normalizeLimitType("SCALE"), "SCALE");
+  assertEquals(normalizeLimitType("CLIP"), "CLIP");
+});
+
+Deno.test("normalizeLimitType - case-insensitive and trims whitespace", () => {
+  assertEquals(normalizeLimitType("scale"), "SCALE");
+  assertEquals(normalizeLimitType("  clip  "), "CLIP");
+});
+
+Deno.test("normalizeLimitType - falls back to OFF for unknown/missing", () => {
+  assertEquals(normalizeLimitType("bogus"), "OFF");
+  assertEquals(normalizeLimitType(undefined), "OFF");
+  assertEquals(normalizeLimitType(null), "OFF");
+  assertEquals(normalizeLimitType(""), "OFF");
+});
+
+Deno.test("normalizeLimitPercent - keeps valid numbers in range", () => {
+  assertEquals(normalizeLimitPercent(25), 25);
+  assertEquals(normalizeLimitPercent(80), 80);
+  assertEquals(normalizeLimitPercent(100), 100);
+});
+
+Deno.test("normalizeLimitPercent - clamps out-of-range to 0..100", () => {
+  assertEquals(normalizeLimitPercent(-5), 0);
+  assertEquals(normalizeLimitPercent(150), 100);
+});
+
+Deno.test("normalizeLimitPercent - non-finite values default to 100", () => {
+  assertEquals(normalizeLimitPercent(NaN), 100);
+  assertEquals(normalizeLimitPercent(Infinity), 100);
+  assertEquals(normalizeLimitPercent(undefined), 100);
+  assertEquals(normalizeLimitPercent("abc"), 100);
+});
+
+Deno.test("normalizeLimitPercent - coerces numeric strings", () => {
+  assertEquals(normalizeLimitPercent("70"), 70);
 });

--- a/tests/rate-profile/rate-calculator.test.ts
+++ b/tests/rate-profile/rate-calculator.test.ts
@@ -117,8 +117,10 @@ Deno.test("normalizeLimitPercent - keeps valid numbers in range", () => {
   assertEquals(normalizeLimitPercent(100), 100);
 });
 
-Deno.test("normalizeLimitPercent - clamps out-of-range to 0..100", () => {
-  assertEquals(normalizeLimitPercent(-5), 0);
+Deno.test("normalizeLimitPercent - clamps out-of-range to Betaflight 25..100", () => {
+  assertEquals(normalizeLimitPercent(-5), 25);
+  assertEquals(normalizeLimitPercent(0), 25);
+  assertEquals(normalizeLimitPercent(10), 25);
   assertEquals(normalizeLimitPercent(150), 100);
 });
 

--- a/tests/rate-profile/rate-calculator.test.ts
+++ b/tests/rate-profile/rate-calculator.test.ts
@@ -1,0 +1,58 @@
+import { assertAlmostEquals, assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { calculateThrottle } from "../../rate-profile/src/rate-calculator.js";
+
+Deno.test("calculateThrottle - limit type OFF leaves output unchanged", () => {
+  const base = calculateThrottle(1.0, 50, 0);
+  assertAlmostEquals(calculateThrottle(1.0, 50, 0, "OFF", 60), base, 1e-9);
+});
+
+Deno.test("calculateThrottle - SCALE multiplies output by percent", () => {
+  const base = calculateThrottle(1.0, 50, 0);
+  assertAlmostEquals(
+    calculateThrottle(1.0, 50, 0, "SCALE", 80),
+    base * 0.8,
+    1e-9,
+  );
+});
+
+Deno.test("calculateThrottle - SCALE at mid stick scales proportionally", () => {
+  const base = calculateThrottle(0.5, 50, 0);
+  assertAlmostEquals(
+    calculateThrottle(0.5, 50, 0, "SCALE", 50),
+    base * 0.5,
+    1e-9,
+  );
+});
+
+Deno.test("calculateThrottle - CLIP caps output at percent ceiling", () => {
+  assertAlmostEquals(
+    calculateThrottle(1.0, 50, 0, "CLIP", 70),
+    0.7,
+    1e-9,
+  );
+});
+
+Deno.test("calculateThrottle - CLIP leaves values below ceiling untouched", () => {
+  // base at input 0.2 is well below 0.7 ceiling
+  const base = calculateThrottle(0.2, 50, 0);
+  assertAlmostEquals(
+    calculateThrottle(0.2, 50, 0, "CLIP", 70),
+    base,
+    1e-9,
+  );
+});
+
+Deno.test("calculateThrottle - 100% limit equals OFF for both modes", () => {
+  const base = calculateThrottle(1.0, 50, 0);
+  assertEquals(calculateThrottle(1.0, 50, 0, "SCALE", 100), base);
+  assertEquals(calculateThrottle(1.0, 50, 0, "CLIP", 100), base);
+});
+
+Deno.test("calculateThrottle - unknown limit type behaves as OFF", () => {
+  const base = calculateThrottle(0.8, 50, 0);
+  assertAlmostEquals(
+    calculateThrottle(0.8, 50, 0, "BOGUS", 50),
+    base,
+    1e-9,
+  );
+});


### PR DESCRIPTION
## Summary
- **rate-profile**: add throttle limit type (Off/Scale/Clip) + limit percent slider, with full graph + CLI import/export integration (#6)
- **rate-profile**: each graph panel has a collapsible header; collapsed state persists in `localStorage` (#7)
- **cli-merge**: each CLI input pane gets a "Load file" button and supports drag-and-drop of files onto the textarea (#15)

## Test plan
- [x] `deno task test` — 71 tests pass, including 7 new throttle-limit tests
- [ ] Open `rate-profile/` and verify the Limit Type dropdown + Limit Percent slider on both profiles
  - Switching to SCALE/CLIP visibly modifies the throttle graph
  - CLI export emits `throttle_limit_type` / `throttle_limit_percent`
  - Pasting a CLI dump with those keys updates the controls
- [ ] Collapse a graph panel, reload the page, confirm it stays collapsed
- [ ] In `cli-merge/`, click "Load file" and select a Betaflight dump; verify it populates the textarea
- [ ] Drag a Betaflight dump file from your desktop onto a textarea; verify the orange dashed overlay appears and the file loads

Resolves #6
Resolves #7
Resolves #15

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4pWCrkX3bXNMwo7c9UQ6u)_