### PR TITLE
cli-merge: validate merged output (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Compare two Betaflight CLI dumps side-by-side and generate a merged output. Usef
 - Comparing tune changes across revisions
 - Extracting specific sections from full dumps
 
-Inputs accept pasted text, a file picker, or drag-and-drop from your desktop.
+Inputs accept pasted text, a file picker, or drag-and-drop from your desktop. The tool follows an **A = base / B = import** convention, detects the Betaflight version in each dump's header, and validates the merged output (unknown keys, duplicates, malformed lines, missing `save`) using A's firmware version as the target.
 
 ### 📈 Rate Profile Comparison
 **Path:** `./rate-profile/`

--- a/cli-merge/index.html
+++ b/cli-merge/index.html
@@ -79,6 +79,125 @@ body {
 .input-actions { display: flex; align-items: center; gap: .4rem; }
 .file-input { display: none; }
 
+.input-hint {
+  font-weight: 400;
+  color: var(--muted);
+  font-size: .72rem;
+  margin-left: .25rem;
+}
+
+/* ── Detected-version pills ── */
+.version-pills {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+.version-pills:empty { display: none; }
+
+.version-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: .3rem;
+  padding: .18rem .55rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: .72rem;
+  font-family: "SF Mono", "Fira Code", monospace;
+  color: var(--text-dim);
+  background: var(--card);
+}
+.version-pill.pill-a { border-color: rgba(88,166,255,.4); color: var(--a); }
+.version-pill.pill-b { border-color: rgba(63,185,80,.4); color: var(--b); }
+.version-pill.pill-mismatch {
+  border-color: rgba(224,123,57,.6);
+  color: var(--orange);
+  background: rgba(224,123,57,.08);
+}
+
+/* ── Findings panel ── */
+.findings-panel {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  padding: .55rem .85rem;
+  margin-bottom: .9rem;
+  font-size: .78rem;
+}
+.findings-panel.sev-error   { border-left-color: var(--orange); }
+.findings-panel.sev-warning { border-left-color: #d29922; }
+.findings-panel.sev-info    { border-left-color: var(--a); }
+
+.findings-summary {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 600;
+  color: var(--text);
+  list-style: none;
+}
+.findings-summary::-webkit-details-marker { display: none; }
+.findings-summary::before {
+  content: "▸";
+  color: var(--muted);
+  font-size: .65rem;
+  transition: transform .12s;
+  display: inline-block;
+}
+.findings-panel[open] .findings-summary::before { transform: rotate(90deg); }
+
+.findings-count {
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: .68rem;
+  padding: .1rem .45rem;
+  border-radius: 10px;
+  background: rgba(255,255,255,.05);
+  color: var(--text-dim);
+}
+.findings-count.count-error   { background: rgba(224,123,57,.15); color: var(--orange); }
+.findings-count.count-warning { background: rgba(210,153,34,.15); color: #d29922; }
+.findings-count.count-info    { background: rgba(88,166,255,.15); color: var(--a); }
+
+.findings-list {
+  list-style: none;
+  margin-top: .5rem;
+  display: flex;
+  flex-direction: column;
+  gap: .3rem;
+}
+.finding {
+  display: flex;
+  align-items: baseline;
+  gap: .5rem;
+  padding: .3rem .1rem;
+  border-top: 1px solid rgba(48,54,61,.5);
+  line-height: 1.4;
+}
+.finding:first-child { border-top: none; }
+.finding-sev {
+  font-size: .62rem;
+  font-weight: 700;
+  padding: .08rem .4rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  flex-shrink: 0;
+}
+.finding-sev.error   { background: rgba(224,123,57,.18); color: var(--orange); }
+.finding-sev.warning { background: rgba(210,153,34,.18); color: #d29922; }
+.finding-sev.info    { background: rgba(88,166,255,.18); color: var(--a); }
+.finding-line {
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: .66rem;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.finding-msg { color: var(--text); }
+
 .drop-zone { position: relative; }
 .drop-zone textarea { width: 100%; }
 
@@ -374,7 +493,7 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
   <div class="input-grid">
     <div>
       <div class="input-row">
-        <div class="input-label"><span class="dot dot-a"></span>CLI A (base)</div>
+        <div class="input-label"><span class="dot dot-a"></span>CLI A · base <span class="input-hint">the config you'll save</span></div>
         <div class="input-actions">
           <button type="button" class="btn btn-ghost btn-sm" data-load-file="cli-a">📁 Load file</button>
           <input type="file" class="file-input" data-target="cli-a" accept=".txt,.cli,.config,.log,text/plain">
@@ -387,7 +506,7 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
     </div>
     <div>
       <div class="input-row">
-        <div class="input-label"><span class="dot dot-b"></span>CLI B (source)</div>
+        <div class="input-label"><span class="dot dot-b"></span>CLI B · import <span class="input-hint">settings to merge in</span></div>
         <div class="input-actions">
           <button type="button" class="btn btn-ghost btn-sm" data-load-file="cli-b">📁 Load file</button>
           <input type="file" class="file-input" data-target="cli-b" accept=".txt,.cli,.config,.log,text/plain">
@@ -404,6 +523,7 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
     <button class="btn" id="compare-btn">Compare</button>
     <button class="btn btn-ghost" id="clear-btn">Clear</button>
     <span class="status-text" id="parse-status"></span>
+    <span class="version-pills" id="version-pills"></span>
   </div>
 
   <!-- ── Step 2: Section picker (hidden until parsed) ── -->
@@ -425,6 +545,7 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
 
     <!-- ── Step 3: Output ── -->
     <hr>
+    <div id="findings-panel" class="findings-panel" hidden></div>
     <div class="out-head row-between">
       <div>
         <h2 style="font-size:.9rem;color:var(--text-dim)">Output</h2>
@@ -450,6 +571,7 @@ hr { border: none; border-top: 1px solid var(--border); margin: 1.25rem 0; }
 <script type="module">
 import { parseCLI, compareSections } from "./src/parser.js";
 import { parseSetCommands, buildOutput } from "./src/output.js";
+import { extractVersion, validate } from "./src/validator.js";
 
 // ── State ──────────────────────────────────────────────────────────────────
 
@@ -460,6 +582,10 @@ const state = {
   selections: {},
   /** @type {Record<string,'a'|'b'>} */
   setSelections: {},
+  /** @type {string|null} */
+  versionA: null,
+  /** @type {string|null} */
+  versionB: null,
 };
 
 // ── Defaults ───────────────────────────────────────────────────────────────
@@ -677,6 +803,63 @@ window.selectAll = function (val) {
 function refreshOutput() {
   const out = buildOutput(state.sections, state.selections, state.setSelections);
   document.getElementById("output-area").value = out;
+  refreshFindings(out);
+}
+
+function refreshFindings(mergedText) {
+  const panel = document.getElementById("findings-panel");
+  const findings = validate({
+    mergedText,
+    sections: state.sections,
+    versionA: state.versionA,
+    versionB: state.versionB,
+  });
+
+  if (!findings.length) {
+    panel.hidden = true;
+    panel.innerHTML = "";
+    return;
+  }
+  panel.hidden = false;
+
+  const counts = { error: 0, warning: 0, info: 0 };
+  for (const f of findings) counts[f.severity] = (counts[f.severity] ?? 0) + 1;
+  const topSev = counts.error ? "error" : counts.warning ? "warning" : "info";
+  panel.className = `findings-panel sev-${topSev}`;
+
+  const countPills = ["error", "warning", "info"]
+    .filter((s) => counts[s])
+    .map((s) => `<span class="findings-count count-${s}">${counts[s]} ${s}${counts[s] === 1 ? "" : "s"}</span>`)
+    .join("");
+
+  const items = findings.map((f) => `
+    <li class="finding">
+      <span class="finding-sev ${f.severity}">${f.severity}</span>
+      ${f.line ? `<span class="finding-line">L${f.line}</span>` : ""}
+      <span class="finding-msg">${escHtml(f.message)}</span>
+    </li>
+  `).join("");
+
+  panel.innerHTML = `
+    <details ${counts.error ? "open" : ""}>
+      <summary class="findings-summary">
+        Issues in merged output ${countPills}
+      </summary>
+      <ul class="findings-list">${items}</ul>
+    </details>
+  `;
+}
+
+function renderVersionPills() {
+  const pills = document.getElementById("version-pills");
+  const { versionA, versionB } = state;
+  const parts = [];
+  if (versionA) parts.push(`<span class="version-pill pill-a">A · ${escHtml(versionA)}</span>`);
+  if (versionB) parts.push(`<span class="version-pill pill-b">B · ${escHtml(versionB)}</span>`);
+  if (versionA && versionB && versionA !== versionB) {
+    parts.push(`<span class="version-pill pill-mismatch" title="A is the validation target">version mismatch</span>`);
+  }
+  pills.innerHTML = parts.join("");
 }
 
 // ── File loading (picker + drag-and-drop) ──────────────────────────────────
@@ -743,6 +926,9 @@ document.getElementById("compare-btn").addEventListener("click", () => {
   state.sections   = compareSections(secA, secB);
   state.selections  = {};
   state.setSelections = {};
+  state.versionA = extractVersion(textA);
+  state.versionB = extractVersion(textB);
+  renderVersionPills();
 
   // Apply defaults
   for (const sec of state.sections) {
@@ -769,6 +955,9 @@ document.getElementById("clear-btn").addEventListener("click", () => {
   state.sections = [];
   state.selections = {};
   state.setSelections = {};
+  state.versionA = null;
+  state.versionB = null;
+  renderVersionPills();
 });
 
 document.getElementById("copy-btn").addEventListener("click", () => {

--- a/cli-merge/src/validator.js
+++ b/cli-merge/src/validator.js
@@ -1,0 +1,144 @@
+import { parseSetCommands } from "./output.js";
+
+/**
+ * Extract a Betaflight semver from a CLI dump's header line, if present.
+ *
+ * Recognizes headers like:
+ *   # Betaflight / STM32F745 (S745) 4.4.0 Nov  1 2022 / 01:00:00 (abc) MSP API: 1.45
+ *
+ * @param {string} text
+ * @returns {string|null} Semver string (e.g. "4.5.1"), or null if not found.
+ */
+export function extractVersion(text) {
+  if (!text) return null;
+  const match = text.match(
+    /Betaflight\s*\/\s*\S+(?:\s+\(\S+\))?\s+(\d+\.\d+\.\d+)/i,
+  );
+  return match ? match[1] : null;
+}
+
+/**
+ * Collect the set of `set` keys defined anywhere in a parsed section array.
+ * @param {Array<{lines: string[]}>} sections
+ * @returns {Set<string>}
+ */
+function collectSetKeys(sections) {
+  const keys = new Set();
+  for (const sec of sections ?? []) {
+    const { sets } = parseSetCommands(sec.lines);
+    for (const k of sets.keys()) keys.add(k);
+  }
+  return keys;
+}
+
+/**
+ * Validate a merged CLI output against the two source dumps.
+ *
+ * Convention: CLI A is the *base* (its firmware version is treated as the
+ * validation target) and CLI B is the *import*. Keys that only appear in B
+ * are flagged when the merged output contains them, because A's firmware
+ * may not recognize them.
+ *
+ * @param {{
+ *   mergedText: string,
+ *   sections?: Array<{id: string, linesA: string[], linesB: string[]}>,
+ *   versionA?: string|null,
+ *   versionB?: string|null,
+ * }} input
+ * @returns {Array<{category: string, severity: 'error'|'warning'|'info', message: string, key?: string, line?: number}>}
+ */
+export function validate({ mergedText, sections = [], versionA, versionB }) {
+  const findings = [];
+
+  if (!versionA && (versionB || mergedText.trim())) {
+    findings.push({
+      category: "missing-version",
+      severity: "warning",
+      message:
+        "Couldn't detect a Betaflight version in CLI A's header — key-drift check is disabled.",
+    });
+  }
+
+  if (versionA && versionB && versionA !== versionB) {
+    findings.push({
+      category: "version-mismatch",
+      severity: "info",
+      message:
+        `CLI A is ${versionA} and CLI B is ${versionB}. Keys that only exist in B may not be recognized by A's firmware.`,
+    });
+  }
+
+  // Build key sets per side from the parsed sections.
+  const secA = sections.map((s) => ({ lines: s.linesA ?? [] }));
+  const secB = sections.map((s) => ({ lines: s.linesB ?? [] }));
+  const keysA = collectSetKeys(secA);
+  const keysB = collectSetKeys(secB);
+
+  const lines = mergedText.split("\n");
+  const seenKeys = new Map(); // key -> first line index
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed.startsWith("set")) continue;
+
+    // Malformed: missing "=" or empty value.
+    const setMatch = /^set\s+(\S+)\s*=\s*(.*)$/.exec(trimmed);
+    if (!setMatch) {
+      findings.push({
+        category: "malformed-set",
+        severity: "error",
+        message: `Malformed set line: "${trimmed}"`,
+        line: i + 1,
+      });
+      continue;
+    }
+    const [, key, value] = setMatch;
+    if (!value.trim()) {
+      findings.push({
+        category: "malformed-set",
+        severity: "error",
+        message: `Empty value for "${key}".`,
+        key,
+        line: i + 1,
+      });
+      continue;
+    }
+
+    // Duplicate key check.
+    if (seenKeys.has(key)) {
+      findings.push({
+        category: "duplicate-key",
+        severity: "error",
+        message: `"${key}" is set more than once (first at line ${seenKeys.get(key) + 1}).`,
+        key,
+        line: i + 1,
+      });
+    } else {
+      seenKeys.set(key, i);
+    }
+
+    // Key-drift heuristic: key came from B but A's firmware doesn't know it.
+    if (versionA && !keysA.has(key) && keysB.has(key)) {
+      findings.push({
+        category: "unknown-key",
+        severity: "warning",
+        message:
+          `"${key}" appears only in CLI B — CLI A (${versionA}) may not recognize it.`,
+        key,
+        line: i + 1,
+      });
+    }
+  }
+
+  // Missing save terminator.
+  const hasSave = lines.some((l) => l.trim() === "save");
+  if (mergedText.trim() && !hasSave) {
+    findings.push({
+      category: "missing-save",
+      severity: "warning",
+      message: "No `save` terminator — Betaflight won't persist these settings.",
+    });
+  }
+
+  return findings;
+}

--- a/cli-merge/src/validator.js
+++ b/cli-merge/src/validator.js
@@ -32,6 +32,28 @@ function collectSetKeys(sections) {
 }
 
 /**
+ * Memoize the A/B key sets per `sections` array instance. `sections` is a
+ * fresh array on every Compare, so caching by reference is sufficient to
+ * avoid re-parsing every finding refresh (which fires on each selection
+ * toggle) without needing manual invalidation.
+ * @type {WeakMap<object, {keysA: Set<string>, keysB: Set<string>}>}
+ */
+const keyCache = new WeakMap();
+
+function keySetsFor(sections) {
+  if (!sections || sections.length === 0) {
+    return { keysA: new Set(), keysB: new Set() };
+  }
+  const cached = keyCache.get(sections);
+  if (cached) return cached;
+  const secA = sections.map((s) => ({ lines: s.linesA ?? [] }));
+  const secB = sections.map((s) => ({ lines: s.linesB ?? [] }));
+  const entry = { keysA: collectSetKeys(secA), keysB: collectSetKeys(secB) };
+  keyCache.set(sections, entry);
+  return entry;
+}
+
+/**
  * Validate a merged CLI output against the two source dumps.
  *
  * Convention: CLI A is the *base* (its firmware version is treated as the
@@ -68,18 +90,16 @@ export function validate({ mergedText, sections = [], versionA, versionB }) {
     });
   }
 
-  // Build key sets per side from the parsed sections.
-  const secA = sections.map((s) => ({ lines: s.linesA ?? [] }));
-  const secB = sections.map((s) => ({ lines: s.linesB ?? [] }));
-  const keysA = collectSetKeys(secA);
-  const keysB = collectSetKeys(secB);
+  const { keysA, keysB } = keySetsFor(sections);
 
   const lines = mergedText.split("\n");
   const seenKeys = new Map(); // key -> first line index
 
   for (let i = 0; i < lines.length; i++) {
     const trimmed = lines[i].trim();
-    if (!trimmed.startsWith("set")) continue;
+    // Match only the `set` command itself — `set<whitespace>...` — so words
+    // like `settings`, `setpoint`, `setup` don't fall into malformed-set.
+    if (!/^set\s/.test(trimmed)) continue;
 
     // Malformed: missing "=" or empty value.
     const setMatch = /^set\s+(\S+)\s*=\s*(.*)$/.exec(trimmed);

--- a/tests/cli-merge/validator.test.ts
+++ b/tests/cli-merge/validator.test.ts
@@ -1,0 +1,135 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { extractVersion, validate } from "../../cli-merge/src/validator.js";
+import { compareSections, parseCLI } from "../../cli-merge/src/parser.js";
+
+Deno.test("extractVersion - reads semver from Betaflight header line", () => {
+  const text =
+    `# Betaflight / STM32F745 (S745) 4.4.0 Nov  1 2022 / 01:00:00 (abc) MSP API: 1.45\nbatch start`;
+  assertEquals(extractVersion(text), "4.4.0");
+});
+
+Deno.test("extractVersion - handles 4.5.x header format", () => {
+  const text = `# Betaflight / STM32H743 (SH74) 4.5.1 Apr 30 2024 / 12:34:56 (def)`;
+  assertEquals(extractVersion(text), "4.5.1");
+});
+
+Deno.test("extractVersion - returns null when no version present", () => {
+  assertEquals(extractVersion("batch start\n# feature"), null);
+});
+
+Deno.test("extractVersion - returns null on empty input", () => {
+  assertEquals(extractVersion(""), null);
+});
+
+const DUMP_A = `# Betaflight / STM32F745 (S745) 4.4.0 Nov  1 2022 / 01:00:00 (abc)
+# start the command batch
+batch start
+
+# master
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 500
+
+profile 0
+
+# profile
+set dterm_lpf1_dyn_min_hz = 75
+
+# save configuration
+save`;
+
+const DUMP_B_NEWER = `# Betaflight / STM32F745 (S745) 4.5.1 Apr 30 2024 / 12:34:56 (def)
+batch start
+
+# master
+set gyro_lpf1_static_hz = 0
+set gyro_lpf2_static_hz = 500
+set new_key_added_in_45 = 42
+
+profile 0
+
+# profile
+set dterm_lpf1_dyn_min_hz = 80
+
+# save configuration
+save`;
+
+function buildContext(a, b) {
+  const secA = parseCLI(a);
+  const secB = parseCLI(b);
+  return { sections: compareSections(secA, secB), versionA: extractVersion(a), versionB: extractVersion(b) };
+}
+
+Deno.test("validate - flags keys introduced only by B when target is A", () => {
+  const ctx = buildContext(DUMP_A, DUMP_B_NEWER);
+  const merged =
+    `# master\nset gyro_lpf1_static_hz = 0\nset new_key_added_in_45 = 42\n\nsave`;
+  const findings = validate({ mergedText: merged, ...ctx });
+  const keyDrift = findings.find((f) => f.category === "unknown-key");
+  assertEquals(keyDrift !== undefined, true);
+  assertEquals(keyDrift.key, "new_key_added_in_45");
+  assertEquals(keyDrift.severity, "warning");
+});
+
+Deno.test("validate - does not flag shared keys as unknown", () => {
+  const ctx = buildContext(DUMP_A, DUMP_B_NEWER);
+  const merged = `# master\nset gyro_lpf1_static_hz = 0\n\nsave`;
+  const findings = validate({ mergedText: merged, ...ctx });
+  assertEquals(findings.some((f) => f.category === "unknown-key"), false);
+});
+
+Deno.test("validate - version mismatch produces an info finding", () => {
+  const ctx = buildContext(DUMP_A, DUMP_B_NEWER);
+  const findings = validate({ mergedText: "save", ...ctx });
+  const mismatch = findings.find((f) => f.category === "version-mismatch");
+  assertEquals(mismatch !== undefined, true);
+  assertEquals(mismatch.severity, "info");
+});
+
+Deno.test("validate - matching versions produce no mismatch finding", () => {
+  const ctx = buildContext(DUMP_A, DUMP_A);
+  const findings = validate({ mergedText: "save", ...ctx });
+  assertEquals(findings.some((f) => f.category === "version-mismatch"), false);
+});
+
+Deno.test("validate - missing version on A disables key-drift check and warns", () => {
+  const noHeader = DUMP_A.split("\n").slice(1).join("\n");
+  const ctx = buildContext(noHeader, DUMP_B_NEWER);
+  const merged = `# master\nset new_key_added_in_45 = 42\nsave`;
+  const findings = validate({ mergedText: merged, ...ctx });
+  assertEquals(findings.some((f) => f.category === "missing-version"), true);
+  assertEquals(findings.some((f) => f.category === "unknown-key"), false);
+});
+
+Deno.test("validate - flags duplicate set keys in the merged output", () => {
+  const ctx = buildContext(DUMP_A, DUMP_A);
+  const merged =
+    `# master\nset gyro_lpf1_static_hz = 0\nset gyro_lpf1_static_hz = 5\n\nsave`;
+  const findings = validate({ mergedText: merged, ...ctx });
+  const dup = findings.find((f) => f.category === "duplicate-key");
+  assertEquals(dup !== undefined, true);
+  assertEquals(dup.key, "gyro_lpf1_static_hz");
+  assertEquals(dup.severity, "error");
+});
+
+Deno.test("validate - flags malformed set lines", () => {
+  const ctx = buildContext(DUMP_A, DUMP_A);
+  const merged = `# master\nset broken_no_equals\nset empty_value =\n\nsave`;
+  const findings = validate({ mergedText: merged, ...ctx });
+  const malformed = findings.filter((f) => f.category === "malformed-set");
+  assertEquals(malformed.length, 2);
+  assertEquals(malformed[0].severity, "error");
+});
+
+Deno.test("validate - warns when the merged output has no save terminator", () => {
+  const ctx = buildContext(DUMP_A, DUMP_A);
+  const merged = `# master\nset gyro_lpf1_static_hz = 0`;
+  const findings = validate({ mergedText: merged, ...ctx });
+  assertEquals(findings.some((f) => f.category === "missing-save"), true);
+});
+
+Deno.test("validate - accepts save on its own line as terminator", () => {
+  const ctx = buildContext(DUMP_A, DUMP_A);
+  const merged = `# master\nset gyro_lpf1_static_hz = 0\nsave`;
+  const findings = validate({ mergedText: merged, ...ctx });
+  assertEquals(findings.some((f) => f.category === "missing-save"), false);
+});

--- a/tests/cli-merge/validator.test.ts
+++ b/tests/cli-merge/validator.test.ts
@@ -135,3 +135,13 @@ Deno.test("validate - accepts save on its own line as terminator", () => {
   const findings = validate({ mergedText: merged, ...ctx });
   assertEquals(findings.some((f) => f.category === "missing-save"), false);
 });
+
+Deno.test("validate - words starting with 'set' are not treated as set commands", () => {
+  const ctx = buildContext(DUMP_A, DUMP_A);
+  // settings, setpoint, setup are not the `set` command; they must not
+  // produce malformed-set findings.
+  const merged =
+    `# master\nsettings blah\nsetpoint = 5\nsetup something\nset gyro_lpf1_static_hz = 0\nsave`;
+  const findings = validate({ mergedText: merged, ...ctx });
+  assertEquals(findings.some((f) => f.category === "malformed-set"), false);
+});

--- a/tests/cli-merge/validator.test.ts
+++ b/tests/cli-merge/validator.test.ts
@@ -56,13 +56,16 @@ save`;
 function buildContext(a, b) {
   const secA = parseCLI(a);
   const secB = parseCLI(b);
-  return { sections: compareSections(secA, secB), versionA: extractVersion(a), versionB: extractVersion(b) };
+  return {
+    sections: compareSections(secA, secB),
+    versionA: extractVersion(a),
+    versionB: extractVersion(b),
+  };
 }
 
 Deno.test("validate - flags keys introduced only by B when target is A", () => {
   const ctx = buildContext(DUMP_A, DUMP_B_NEWER);
-  const merged =
-    `# master\nset gyro_lpf1_static_hz = 0\nset new_key_added_in_45 = 42\n\nsave`;
+  const merged = `# master\nset gyro_lpf1_static_hz = 0\nset new_key_added_in_45 = 42\n\nsave`;
   const findings = validate({ mergedText: merged, ...ctx });
   const keyDrift = findings.find((f) => f.category === "unknown-key");
   assertEquals(keyDrift !== undefined, true);
@@ -102,8 +105,7 @@ Deno.test("validate - missing version on A disables key-drift check and warns", 
 
 Deno.test("validate - flags duplicate set keys in the merged output", () => {
   const ctx = buildContext(DUMP_A, DUMP_A);
-  const merged =
-    `# master\nset gyro_lpf1_static_hz = 0\nset gyro_lpf1_static_hz = 5\n\nsave`;
+  const merged = `# master\nset gyro_lpf1_static_hz = 0\nset gyro_lpf1_static_hz = 5\n\nsave`;
   const findings = validate({ mergedText: merged, ...ctx });
   const dup = findings.find((f) => f.category === "duplicate-key");
   assertEquals(dup !== undefined, true);


### PR DESCRIPTION
## Summary
Implements **Phase 1** of the plan from #17 (comment [4817293144](https://github.com/cori/fpv-tools/issues/17#issuecomment-4817293144)):

- New `cli-merge/src/validator.js`
  - `extractVersion(text)` — pulls the semver from Betaflight header lines
  - `validate({ mergedText, sections, versionA, versionB })` — returns findings with severity `error`/`warning`/`info` covering:
    - **version-mismatch** — A and B are different Betaflight versions
    - **missing-version** — A's header has no detectable version (heuristic disabled, warning surfaced)
    - **unknown-key** — a `set` key came from B but doesn't appear anywhere in A (A's firmware may not know it)
    - **duplicate-key** — same `set` key twice in the output
    - **malformed-set** — missing `=`, empty value
    - **missing-save** — no `save` terminator
- UI wiring in `cli-merge/index.html`
  - Input labels clarified as **CLI A · base** and **CLI B · import** with subtitles.
  - Detected-version pills appear next to the parse-status line after Compare; a "version mismatch" pill lights up when they differ. A is the validation target.
  - Collapsible **Issues** panel above the output textarea groups findings by severity; auto-opens when any errors are present.
- 13 new tests in `tests/cli-merge/validator.test.ts`. Full suite is 94/94.

Phase 2 (bundled key-lists per version) is deferred per the issue discussion.

## Test plan
- [x] `deno task test` — 94 tests pass
- [ ] Open `cli-merge/`, paste two dumps from different Betaflight versions, click Compare
  - Verify A/B version pills appear + mismatch pill lights up
  - Verify the Issues panel lists any `unknown-key` warnings for keys from B
- [ ] Paste same dump into both sides, verify no `unknown-key` findings and no mismatch pill
- [ ] Selecting "Both" for a section whose set-picker introduces a duplicate produces a `duplicate-key` error
- [ ] Clear button resets pills and hides the findings panel

Resolves #17

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4pWCrkX3bXNMwo7c9UQ6u)_