### PR TITLE
ci: allow manual re-runs of the Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to `.github/workflows/deploy.yml` so a Pages deploy can be manually re-triggered from the Actions tab

## Context
The last two `Deploy to GitHub Pages` runs on `main` (run 28705286079) failed:
- Attempt 1: transient GitHub Pages error (`Deployment failed, try again later.`)
- Attempt 2 (a re-run of the same run): failed with `Multiple artifacts named "github-pages" were unexpectedly found` — re-running keeps the same run ID, so the stale artifact from attempt 1 was still present when attempt 2 uploaded its own

Re-running again would hit the same duplicate-artifact problem, since the stale artifact persists for the life of that run ID. A fresh run (new run ID) is needed to clear it. Merging this PR triggers exactly that, and going forward `workflow_dispatch` makes it possible to trigger a clean re-run on demand instead of using "re-run failed jobs".

## Test plan
- [x] `deploy.yml` YAML is valid (single-key addition, no other changes)
- [ ] After merge, confirm the resulting Pages deploy run succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01KG8EFfK7CGbigiCYnFYAGW)_