### PR TITLE
feat: add Prop / Motor Sizer tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Characterize an FPV powertrain from prop size, blade count, motor size, KV, batt
 - **Suggested ranges** — e.g. pick a 5″ prop on 6S and get a recommended KV band and a list of suitable stator sizes; enter a motor and get the prop diameters it suits
 - **Style-aware** — cinematic / long-range / freestyle / racing biases pitch, KV, and AUW recommendations
 - **Presets** — tiny whoop, 3″ 4S, 5″ 6S freestyle, 5″ 4S race, 7″ long-range starting points
-- Inputs persist in localStorage; estimates are simplified-physics ballparks (±20–30%), not thrust-stand data
+- **Advanced panel** — adjust the motor load factor, battery chemistry (LiPo/LiHV/Li-Ion) and voltage basis (full charge / nominal / under load), and altitude; add battery capacity for a hover-endurance estimate; or enter one thrust-stand measurement to calibrate the whole model to your bench numbers
+- Inputs persist in localStorage; estimates are simplified-physics ballparks (±20–30% unless calibrated), not thrust-stand data
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Compare two Betaflight Actual Rates profiles with real-time visualization. Featu
 - **Visibility toggles** — focus on specific profiles or axes
 - **Mobile-responsive** — works on tablet and phone
 
+### 🔩 Prop / Motor Sizer
+**Path:** `./prop-motor-sizer/`
+
+Characterize an FPV powertrain from prop size, blade count, motor size, KV, battery cells, and all-up weight — or leave any of those blank and get suggested ranges derived from what you did enter. Features:
+- **Flight character verdicts** — thrust-to-weight interpretation, motor/prop torque match, KV-vs-voltage rev match, and tip-speed warnings
+- **Estimated numbers** — static thrust, hover throttle, RPM under load, tip speed (Mach), pitch speed, hover and full-throttle current draw, disc loading
+- **Suggested ranges** — e.g. pick a 5″ prop on 6S and get a recommended KV band and a list of suitable stator sizes; enter a motor and get the prop diameters it suits
+- **Style-aware** — cinematic / long-range / freestyle / racing biases pitch, KV, and AUW recommendations
+- **Presets** — tiny whoop, 3″ 4S, 5″ 6S freestyle, 5″ 4S race, 7″ long-range starting points
+- Inputs persist in localStorage; estimates are simplified-physics ballparks (±20–30%), not thrust-stand data
+
 ## Getting Started
 
 1. **Open fpv-tools in your browser:** https://cori.github.io/fpv-tools/
@@ -106,6 +117,12 @@ fpv-tools/
 ├── igow/
 │   ├── index.html          # IGOW Challenge Reference tool
 │   └── igow.db              # SQLite dataset (queried via sql.js)
+├── prop-motor-sizer/
+│   ├── index.html          # Prop / Motor Sizer tool
+│   ├── styles.css
+│   └── src/
+│       ├── app.js          # DOM wiring and rendering
+│       └── sizer-calculator.js  # Pure sizing math (tested)
 └── .github/
     └── workflows/
         ├── deploy.yml      # GitHub Pages auto-deploy on push

--- a/index.html
+++ b/index.html
@@ -1,111 +1,140 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>FPV Tools</title>
-<link rel="stylesheet" href="./assets/site-header.css">
-<style>
-:root {
-  --bg:      #0d1117;
-  --surface: #161b22;
-  --card:    #21262d;
-  --border:  #30363d;
-  --orange:  #e07b39;
-  --text:    #c9d1d9;
-  --muted:   #6e7681;
-}
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FPV Tools</title>
+    <link rel="stylesheet" href="./assets/site-header.css">
+    <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --card: #21262d;
+      --border: #30363d;
+      --orange: #e07b39;
+      --text: #c9d1d9;
+      --muted: #6e7681;
+    }
 
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
 
-body {
-  background: var(--bg);
-  color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
 
-main {
-  max-width: 640px;
-  margin: 3rem auto;
-  padding: 0 1.5rem;
-  flex: 1;
-}
+    main {
+      max-width: 640px;
+      margin: 3rem auto;
+      padding: 0 1.5rem;
+      flex: 1;
+    }
 
-h2 {
-  font-size: .72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--muted);
-  margin-bottom: .75rem;
-}
+    h2 {
+      font-size: .72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--muted);
+      margin-bottom: .75rem;
+    }
 
-.tool-list { display: flex; flex-direction: column; gap: .5rem; }
+    .tool-list {
+      display: flex;
+      flex-direction: column;
+      gap: .5rem;
+    }
 
-.tool-card {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: .9rem 1.1rem;
-  text-decoration: none;
-  color: inherit;
-  transition: border-color .15s;
-}
-.tool-card:hover { border-color: var(--orange); }
+    .tool-card {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: .9rem 1.1rem;
+      text-decoration: none;
+      color: inherit;
+      transition: border-color .15s;
+    }
+    .tool-card:hover {
+      border-color: var(--orange);
+    }
 
-.tool-icon { font-size: 1.4rem; flex-shrink: 0; }
+    .tool-icon {
+      font-size: 1.4rem;
+      flex-shrink: 0;
+    }
 
-.tool-info h3 { font-size: .92rem; font-weight: 600; margin-bottom: .15rem; }
-.tool-info p  { font-size: .78rem; color: var(--muted); line-height: 1.4; }
+    .tool-info h3 {
+      font-size: .92rem;
+      font-weight: 600;
+      margin-bottom: .15rem;
+    }
+    .tool-info p {
+      font-size: .78rem;
+      color: var(--muted);
+      line-height: 1.4;
+    }
 
-footer {
-  text-align: center;
-  padding: 1.5rem;
-  font-size: .75rem;
-  color: var(--muted);
-  border-top: 1px solid var(--border);
-}
-</style>
-</head>
-<body>
+    footer {
+      text-align: center;
+      padding: 1.5rem;
+      font-size: .75rem;
+      color: var(--muted);
+      border-top: 1px solid var(--border);
+    }
+    </style>
+  </head>
+  <body>
+    <fpv-header root="./" icon="⚡" heading="FPV Tools"
+      subtitle="Browser-based utilities for Betaflight and FPV flying" home></fpv-header>
+    <script type="module" src="./assets/site-header.js"></script>
 
-<fpv-header root="./" icon="⚡" heading="FPV Tools" subtitle="Browser-based utilities for Betaflight and FPV flying" home></fpv-header>
-<script type="module" src="./assets/site-header.js"></script>
-
-<main>
-  <h2>Tools</h2>
-  <div class="tool-list">
-    <a class="tool-card" href="./cli-merge/">
-      <span class="tool-icon">🔀</span>
-      <div class="tool-info">
-        <h3>CLI Merge</h3>
-        <p>Paste two Betaflight CLI dumps, compare by section, and generate a merged CLI output ready to paste into Betaflight.</p>
+    <main>
+      <h2>Tools</h2>
+      <div class="tool-list">
+        <a class="tool-card" href="./cli-merge/">
+          <span class="tool-icon">🔀</span>
+          <div class="tool-info">
+            <h3>CLI Merge</h3>
+            <p>Paste two Betaflight CLI dumps, compare by section, and generate a merged CLI output ready to paste into Betaflight.</p>
+          </div>
+        </a>
+        <a class="tool-card" href="./rate-profile/">
+          <span class="tool-icon">📈</span>
+          <div class="tool-info">
+            <h3>Rate Profile Comparison</h3>
+            <p>Compare two Betaflight Actual Rates profiles side-by-side. Visualize roll, pitch, yaw, and throttle curves. Import from CLI dumps, save history, and export ready-to-paste CLI commands.</p>
+          </div>
+        </a>
+        <a class="tool-card" href="./prop-motor-sizer/">
+          <span class="tool-icon">🔩</span>
+          <div class="tool-info">
+            <h3>Prop / Motor Sizer</h3>
+            <p>Enter prop, motor, battery, and weight to estimate thrust, hover throttle, and flight character — or leave fields blank to get suggested ranges for the parts you haven't picked.</p>
+          </div>
+        </a>
+        <a class="tool-card" href="./igow/">
+          <span class="tool-icon">🏆</span>
+          <div class="tool-info">
+            <h3>IGOW Challenge Reference</h3>
+            <p>All International Game of WHOOP challenges from IGOW1–6 with trick components. Filter by season, trick, or search. Cross-reference which challenges feature each FPV trick.</p>
+          </div>
+        </a>
       </div>
-    </a>
-    <a class="tool-card" href="./rate-profile/">
-      <span class="tool-icon">📈</span>
-      <div class="tool-info">
-        <h3>Rate Profile Comparison</h3>
-        <p>Compare two Betaflight Actual Rates profiles side-by-side. Visualize roll, pitch, yaw, and throttle curves. Import from CLI dumps, save history, and export ready-to-paste CLI commands.</p>
-      </div>
-    </a>
-    <a class="tool-card" href="./igow/">
-      <span class="tool-icon">🏆</span>
-      <div class="tool-info">
-        <h3>IGOW Challenge Reference</h3>
-        <p>All International Game of WHOOP challenges from IGOW1–6 with trick components. Filter by season, trick, or search. Cross-reference which challenges feature each FPV trick.</p>
-      </div>
-    </a>
-  </div>
-</main>
+    </main>
 
-<footer>fpv-tools · open source · <a href="https://github.com/cori/fpv-tools/commit/__GIT_SHA__" aria-label="View deployed commit __GIT_SHA__ on GitHub" style="color:inherit;text-decoration:none">__GIT_SHA__</a></footer>
-
-</body>
+    <footer>fpv-tools · open source · <a href="https://github.com/cori/fpv-tools/commit/__GIT_SHA__" aria-label="View deployed commit __GIT_SHA__ on GitHub" style="color:inherit;text-decoration:none">__GIT_SHA__</a></footer>
+  </body>
 </html>

--- a/prop-motor-sizer/index.html
+++ b/prop-motor-sizer/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FPV Prop / Motor Sizer</title>
+    <link rel="stylesheet" href="../assets/site-header.css">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <fpv-header root="../" icon="🔩" heading="Prop / Motor Sizer"
+      subtitle="Characterize a powertrain, or find the right ranges for the parts you haven't picked"></fpv-header>
+    <script type="module" src="../assets/site-header.js"></script>
+
+    <div class="container">
+      <div class="sizer-layout">
+        <!-- Inputs -->
+        <section class="panel inputs-panel">
+          <h2>Build</h2>
+          <p
+            class="hint">Fill in what you know. Anything left blank gets a suggested range based on the rest.</p>
+
+          <div class="field-row">
+            <label class="field">
+              <span>Preset</span>
+              <select id="preset">
+                <option value="">— custom —</option>
+                <option value="whoop">Tiny Whoop (1S)</option>
+                <option value="3in4s">3″ 4S Freestyle</option>
+                <option value="5in6s">5″ 6S Freestyle</option>
+                <option value="5in4s-race">5″ 4S Race</option>
+                <option value="7in6s-lr">7″ 6S Long Range</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Flying style</span>
+              <select id="style">
+                <option value="cinematic">Cinematic</option>
+                <option value="longrange">Long range</option>
+                <option value="freestyle" selected>Freestyle</option>
+                <option value="racing">Racing</option>
+              </select>
+            </label>
+          </div>
+
+          <h3>Prop</h3>
+          <div class="field-row">
+            <label class="field">
+              <span>Diameter <em>in</em></span>
+              <input type="number" id="diameter" min="0.5" max="15" step="0.1" placeholder="auto">
+            </label>
+            <label class="field">
+              <span>Pitch <em>in</em></span>
+              <input type="number" id="pitch" min="0.5" max="12" step="0.1" placeholder="auto">
+            </label>
+            <label class="field">
+              <span>Blades</span>
+              <select id="blades">
+                <option value="2">2</option>
+                <option value="3" selected>3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+              </select>
+            </label>
+          </div>
+
+          <h3>Motor</h3>
+          <div class="field-row">
+            <label class="field">
+              <span>Stator size</span>
+              <input type="text" id="motor-size" inputmode="numeric" placeholder="auto (e.g. 2207)">
+            </label>
+            <label class="field">
+              <span>KV</span>
+              <input type="number" id="kv" min="100" max="40000" step="50" placeholder="auto">
+            </label>
+          </div>
+
+          <h3>Power &amp; weight</h3>
+          <div class="field-row">
+            <label class="field">
+              <span>Battery</span>
+              <select id="cells">
+                <option value="">auto</option>
+                <option value="1">1S</option>
+                <option value="2">2S</option>
+                <option value="3">3S</option>
+                <option value="4">4S</option>
+                <option value="5">5S</option>
+                <option value="6">6S</option>
+                <option value="7">7S</option>
+                <option value="8">8S</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>AUW <em>g</em></span>
+              <input type="number" id="auw" min="10" max="10000" step="5" placeholder="auto">
+            </label>
+            <label class="field">
+              <span>Motors</span>
+              <select id="motor-count">
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4" selected>4</option>
+                <option value="6">6</option>
+                <option value="8">8</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="actions">
+            <button type="button" id="reset" class="btn-secondary">Clear all</button>
+          </div>
+        </section>
+
+        <!-- Results -->
+        <section class="panel results-panel">
+          <div id="empty-state" class="empty-state">
+                    Enter a prop size, motor, battery, or weight to get started — or pick a preset.
+                </div>
+
+          <div id="verdicts-section" hidden>
+            <h2>Flight character</h2>
+            <ul id="verdicts" class="verdicts"></ul>
+          </div>
+
+          <div id="metrics-section" hidden>
+            <h2>Estimated numbers</h2>
+            <div id="metrics" class="metrics-grid"></div>
+          </div>
+
+          <div id="recs-section" hidden>
+            <h2>Suggested ranges for what's unset</h2>
+            <ul id="recommendations" class="recs"></ul>
+          </div>
+
+          <p class="disclaimer">
+                    Estimates use simplified physics (static-thrust and momentum-theory models) at
+                    full-charge voltage (4.2&nbsp;V/cell), assuming props load motors to ~75% of their
+                    unloaded RPM ceiling. Expect ±20–30% versus a thrust stand — use these numbers to
+                    compare options and catch mismatches, not to size fuses.
+                </p>
+        </section>
+      </div>
+    </div>
+
+    <script type="module" src="src/app.js"></script>
+  </body>
+</html>

--- a/prop-motor-sizer/index.html
+++ b/prop-motor-sizer/index.html
@@ -110,6 +110,52 @@
             </label>
           </div>
 
+          <details class="advanced">
+            <summary>Advanced</summary>
+            <div class="field-row">
+              <label class="field">
+                <span>Chemistry</span>
+                <select id="chemistry">
+                  <option value="lipo" selected>LiPo</option>
+                  <option value="lihv">LiHV</option>
+                  <option value="liion">Li-Ion</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Voltage basis</span>
+                <select id="volt-basis">
+                  <option value="full" selected>Full charge</option>
+                  <option value="nominal">Nominal</option>
+                  <option value="load">Under load</option>
+                </select>
+              </label>
+            </div>
+            <div class="field-row">
+              <label class="field">
+                <span>Motor load factor <em><output id="load-factor-out">75%</output> of KV×V</em></span>
+                <input type="range" id="load-factor" min="60" max="90" step="1" value="75">
+              </label>
+            </div>
+            <div class="field-row">
+              <label class="field">
+                <span>Altitude <em>m</em></span>
+                <input type="number" id="altitude" min="0" max="5000" step="50"
+                  placeholder="sea level">
+              </label>
+              <label class="field">
+                <span>Capacity <em>mAh</em></span>
+                <input type="number" id="capacity" min="50" max="30000" step="50" placeholder="—">
+              </label>
+            </div>
+            <div class="field-row">
+              <label class="field">
+                <span>Measured max thrust <em>g/motor</em></span>
+                <input type="number" id="measured-thrust" min="1" max="20000" step="10"
+                  placeholder="calibrate from a thrust stand">
+              </label>
+            </div>
+          </details>
+
           <div class="actions">
             <button type="button" id="reset" class="btn-secondary">Clear all</button>
           </div>
@@ -137,11 +183,13 @@
           </div>
 
           <p class="disclaimer">
-                    Estimates use simplified physics (static-thrust and momentum-theory models) at
-                    full-charge voltage (4.2&nbsp;V/cell), assuming props load motors to ~75% of their
-                    unloaded RPM ceiling. Expect ±20–30% versus a thrust stand — use these numbers to
-                    compare options and catch mismatches, not to size fuses.
-                </p>
+            Estimates use simplified physics (static-thrust and momentum-theory models). By
+            default they're computed at full-charge voltage assuming props load motors to
+            ~75% of their unloaded RPM ceiling — both adjustable under Advanced, along with
+            altitude, battery chemistry, and a thrust-stand calibration point. Expect ±20–30%
+            versus a bench unless calibrated — use these numbers to compare options and catch
+            mismatches, not to size fuses.
+          </p>
         </section>
       </div>
     </div>

--- a/prop-motor-sizer/src/app.js
+++ b/prop-motor-sizer/src/app.js
@@ -1,0 +1,290 @@
+import { analyze, parseMotorSize } from "./sizer-calculator.js";
+
+const STORAGE_KEY = "prop-motor-sizer.inputs.v1";
+
+const FIELD_IDS = [
+  "style",
+  "diameter",
+  "pitch",
+  "blades",
+  "motor-size",
+  "kv",
+  "cells",
+  "auw",
+  "motor-count",
+];
+
+const PRESETS = {
+  whoop: {
+    style: "freestyle",
+    diameter: "1.2",
+    pitch: "0.9",
+    blades: "3",
+    "motor-size": "0802",
+    kv: "25000",
+    cells: "1",
+    auw: "27",
+    "motor-count": "4",
+  },
+  "3in4s": {
+    style: "freestyle",
+    diameter: "3",
+    pitch: "2.5",
+    blades: "3",
+    "motor-size": "1404",
+    kv: "3800",
+    cells: "4",
+    auw: "250",
+    "motor-count": "4",
+  },
+  "5in6s": {
+    style: "freestyle",
+    diameter: "5",
+    pitch: "4.5",
+    blades: "3",
+    "motor-size": "2207",
+    kv: "1800",
+    cells: "6",
+    auw: "680",
+    "motor-count": "4",
+  },
+  "5in4s-race": {
+    style: "racing",
+    diameter: "5.1",
+    pitch: "4.9",
+    blades: "3",
+    "motor-size": "2306",
+    kv: "2600",
+    cells: "4",
+    auw: "550",
+    "motor-count": "4",
+  },
+  "7in6s-lr": {
+    style: "longrange",
+    diameter: "7",
+    pitch: "4",
+    blades: "2",
+    "motor-size": "2806.5",
+    kv: "1300",
+    cells: "6",
+    auw: "1100",
+    "motor-count": "4",
+  },
+};
+
+const $ = (id) => document.getElementById(id);
+
+function num(id) {
+  const v = $(id).value.trim();
+  if (v === "") return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function readInputs() {
+  return {
+    diameterIn: num("diameter"),
+    pitchIn: num("pitch"),
+    blades: num("blades"),
+    motorSize: $("motor-size").value.trim() || undefined,
+    kv: num("kv"),
+    cells: num("cells"),
+    auwGrams: num("auw"),
+    motorCount: num("motor-count"),
+    style: $("style").value,
+  };
+}
+
+const fmtInt = (n) => Math.round(n).toLocaleString("en-US");
+
+function metricCard({ label, value, sub, highlight }) {
+  return `<div class="metric${highlight ? " highlight" : ""}">
+    <div class="metric-label">${label}</div>
+    <div class="metric-value">${value}</div>
+    ${sub ? `<div class="metric-sub">${sub}</div>` : ""}
+  </div>`;
+}
+
+function renderMetrics(m) {
+  const cards = [];
+  if (m.twr !== undefined) {
+    cards.push(metricCard({
+      label: "Thrust : weight",
+      value: `${m.twr.toFixed(1)} : 1`,
+      highlight: true,
+    }));
+  }
+  if (m.hoverThrottlePct !== undefined) {
+    cards.push(metricCard({
+      label: "Hover throttle",
+      value: `≈ ${Math.round(m.hoverThrottlePct)}%`,
+    }));
+  }
+  if (m.thrustPerMotorG !== undefined) {
+    cards.push(metricCard({
+      label: "Static thrust",
+      value: `${fmtInt(m.thrustPerMotorG)} g/motor`,
+      sub: `${fmtInt(m.totalThrustG)} g total`,
+    }));
+  }
+  if (m.loadedRpm !== undefined) {
+    cards.push(metricCard({
+      label: "RPM under load",
+      value: `≈ ${fmtInt(m.loadedRpm)}`,
+      sub: `unloaded ceiling ${fmtInt(m.maxRpm)}`,
+    }));
+  }
+  if (m.tipSpeedMs !== undefined) {
+    cards.push(metricCard({
+      label: "Tip speed",
+      value: `${Math.round(m.tipSpeedMs)} m/s`,
+      sub: `Mach ${m.tipMach.toFixed(2)}`,
+    }));
+  }
+  if (m.pitchSpeedKmh !== undefined) {
+    cards.push(metricCard({
+      label: "Pitch speed",
+      value: `${Math.round(m.pitchSpeedKmh)} km/h`,
+      sub: `${Math.round(m.pitchSpeedMph)} mph (zero-slip top speed)`,
+    }));
+  }
+  if (m.hoverCurrentA !== undefined) {
+    cards.push(metricCard({
+      label: "Hover draw",
+      value: `≈ ${m.hoverCurrentA.toFixed(1)} A`,
+      sub: `${fmtInt(m.hoverPowerW)} W`,
+    }));
+  }
+  if (m.maxCurrentA !== undefined) {
+    cards.push(metricCard({
+      label: "Full-throttle draw",
+      value: `≈ ${fmtInt(m.maxCurrentA)} A`,
+      sub: `${Math.round(m.maxCurrentPerMotorA)} A/motor · ${fmtInt(m.maxPowerW)} W`,
+    }));
+  }
+  if (m.discLoadingGCm2 !== undefined) {
+    cards.push(metricCard({
+      label: "Disc loading",
+      value: `${m.discLoadingGCm2.toFixed(2)} g/cm²`,
+    }));
+  }
+  if (m.statorVolumeMm3 !== undefined) {
+    cards.push(metricCard({
+      label: "Stator volume",
+      value: `${fmtInt(m.statorVolumeMm3)} mm³`,
+    }));
+  }
+  return cards.join("");
+}
+
+const REC_RENDERERS = {
+  kv: (r) => ["Motor KV", `${fmtInt(r.min)}–${fmtInt(r.max)} KV`, `ideal ≈ ${fmtInt(r.ideal)} KV`],
+  cells: (r) => [
+    "Battery",
+    r.min === r.max ? `${r.ideal}S` : `${r.min}S–${r.max}S`,
+    `ideal ${r.ideal}S`,
+  ],
+  motorSizes: (r) => ["Motor size", r.sizes.join(", "), null],
+  diameter: (r) => ["Prop diameter", `${r.min}–${r.max}″`, `ideal ≈ ${r.ideal}″`],
+  pitch: (r) => ["Prop pitch", `${r.min}–${r.max}″`, null],
+  auw: (r) => ["All-up weight", `${fmtInt(r.min)}–${fmtInt(r.max)} g`, null],
+};
+
+function renderRecommendations(recs) {
+  return Object.entries(recs).map(([key, rec]) => {
+    const renderer = REC_RENDERERS[key];
+    if (!renderer) return "";
+    const [label, value, detail] = renderer(rec);
+    return `<li>
+      <span class="rec-field">${label}:</span>
+      <span class="rec-value">${value}</span>${
+      detail ? ` <span class="rec-basis">${detail}</span>` : ""
+    }
+      <span class="rec-basis">based on ${rec.basis}</span>
+    </li>`;
+  }).join("");
+}
+
+function render() {
+  const inputs = readInputs();
+  const { metrics, recommendations, verdicts } = analyze(inputs);
+
+  // Flag an unparseable motor size right on the field
+  const motorField = $("motor-size");
+  const motorText = motorField.value.trim();
+  motorField.style.borderColor = motorText && !parseMotorSize(motorText) ? "var(--color-bad)" : "";
+
+  const hasMetrics = Object.keys(metrics).length > 0;
+  const hasRecs = Object.keys(recommendations).length > 0;
+  const hasVerdicts = verdicts.length > 0;
+
+  $("empty-state").hidden = hasMetrics || hasRecs;
+  $("verdicts-section").hidden = !hasVerdicts;
+  $("metrics-section").hidden = !hasMetrics;
+  $("recs-section").hidden = !hasRecs;
+
+  $("verdicts").innerHTML = verdicts
+    .map((v) => `<li class="${v.level}">${v.text}</li>`)
+    .join("");
+  $("metrics").innerHTML = renderMetrics(metrics);
+  $("recommendations").innerHTML = renderRecommendations(recommendations);
+}
+
+function saveInputs() {
+  const state = {};
+  for (const id of FIELD_IDS) state[id] = $(id).value;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Private browsing or storage full - persistence is best-effort
+  }
+}
+
+function loadInputs() {
+  try {
+    const state = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    for (const id of FIELD_IDS) {
+      if (typeof state[id] === "string") $(id).value = state[id];
+    }
+  } catch {
+    // Corrupt state - start fresh
+  }
+}
+
+function applyPreset(name) {
+  const preset = PRESETS[name];
+  if (!preset) return;
+  for (const [id, value] of Object.entries(preset)) $(id).value = value;
+}
+
+function init() {
+  loadInputs();
+
+  for (const id of FIELD_IDS) {
+    $(id).addEventListener("input", () => {
+      $("preset").value = "";
+      saveInputs();
+      render();
+    });
+  }
+
+  $("preset").addEventListener("change", (e) => {
+    applyPreset(e.target.value);
+    saveInputs();
+    render();
+  });
+
+  $("reset").addEventListener("click", () => {
+    for (const id of FIELD_IDS) $(id).value = "";
+    $("blades").value = "3";
+    $("motor-count").value = "4";
+    $("style").value = "freestyle";
+    $("preset").value = "";
+    saveInputs();
+    render();
+  });
+
+  render();
+}
+
+init();

--- a/prop-motor-sizer/src/app.js
+++ b/prop-motor-sizer/src/app.js
@@ -14,6 +14,34 @@ const FIELD_IDS = [
   "motor-count",
 ];
 
+// Advanced fields tune the model rather than describe the build, so
+// changing them keeps the selected preset label.
+const ADVANCED_IDS = [
+  "chemistry",
+  "volt-basis",
+  "load-factor",
+  "altitude",
+  "capacity",
+  "measured-thrust",
+];
+
+const ADVANCED_DEFAULTS = {
+  chemistry: "lipo",
+  "volt-basis": "full",
+  "load-factor": "75",
+  altitude: "",
+  capacity: "",
+  "measured-thrust": "",
+};
+
+// Per-cell voltage by chemistry and basis. "nominal" also sets the voltage
+// used for battery-energy (endurance) math.
+const CHEMISTRY = {
+  lipo: { full: 4.2, nominal: 3.7, load: 3.5 },
+  lihv: { full: 4.35, nominal: 3.8, load: 3.6 },
+  liion: { full: 4.2, nominal: 3.6, load: 3.3 },
+};
+
 const PRESETS = {
   whoop: {
     style: "freestyle",
@@ -82,6 +110,7 @@ function num(id) {
 }
 
 function readInputs() {
+  const chem = CHEMISTRY[$("chemistry").value] ?? CHEMISTRY.lipo;
   return {
     diameterIn: num("diameter"),
     pitchIn: num("pitch"),
@@ -92,6 +121,13 @@ function readInputs() {
     auwGrams: num("auw"),
     motorCount: num("motor-count"),
     style: $("style").value,
+    cellVoltage: chem[$("volt-basis").value] ?? chem.full,
+    cellVoltageFull: chem.full,
+    cellVoltageNominal: chem.nominal,
+    loadFactor: (num("load-factor") ?? 75) / 100,
+    altitudeM: num("altitude"),
+    capacityMah: num("capacity"),
+    measuredThrustG: num("measured-thrust"),
   };
 }
 
@@ -131,7 +167,14 @@ function renderMetrics(m) {
     cards.push(metricCard({
       label: "RPM under load",
       value: `≈ ${fmtInt(m.loadedRpm)}`,
-      sub: `unloaded ceiling ${fmtInt(m.maxRpm)}`,
+      sub: `unloaded ceiling ${fmtInt(m.maxRpm)} at ${m.voltage.toFixed(1)} V`,
+    }));
+  }
+  if (m.hoverFlightTimeMin !== undefined) {
+    cards.push(metricCard({
+      label: "Hover endurance",
+      value: `≈ ${m.hoverFlightTimeMin.toFixed(0)} min`,
+      sub: "ideal hover, 80% usable — mixed flying is far less",
     }));
   }
   if (m.tipSpeedMs !== undefined) {
@@ -172,6 +215,13 @@ function renderMetrics(m) {
     cards.push(metricCard({
       label: "Stator volume",
       value: `${fmtInt(m.statorVolumeMm3)} mm³`,
+    }));
+  }
+  if (m.airDensity !== undefined) {
+    cards.push(metricCard({
+      label: "Air density",
+      value: `${m.airDensity.toFixed(3)} kg/m³`,
+      sub: `${Math.round((m.airDensity / 1.225 - 1) * 100)}% vs sea level`,
     }));
   }
   return cards.join("");
@@ -232,7 +282,7 @@ function render() {
 
 function saveInputs() {
   const state = {};
-  for (const id of FIELD_IDS) state[id] = $(id).value;
+  for (const id of [...FIELD_IDS, ...ADVANCED_IDS]) state[id] = $(id).value;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch {
@@ -243,12 +293,16 @@ function saveInputs() {
 function loadInputs() {
   try {
     const state = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
-    for (const id of FIELD_IDS) {
+    for (const id of [...FIELD_IDS, ...ADVANCED_IDS]) {
       if (typeof state[id] === "string") $(id).value = state[id];
     }
   } catch {
     // Corrupt state - start fresh
   }
+}
+
+function syncLoadFactorOut() {
+  $("load-factor-out").textContent = `${$("load-factor").value}%`;
 }
 
 function applyPreset(name) {
@@ -259,10 +313,19 @@ function applyPreset(name) {
 
 function init() {
   loadInputs();
+  syncLoadFactorOut();
 
   for (const id of FIELD_IDS) {
     $(id).addEventListener("input", () => {
       $("preset").value = "";
+      saveInputs();
+      render();
+    });
+  }
+
+  for (const id of ADVANCED_IDS) {
+    $(id).addEventListener("input", () => {
+      syncLoadFactorOut();
       saveInputs();
       render();
     });
@@ -280,6 +343,8 @@ function init() {
     $("motor-count").value = "4";
     $("style").value = "freestyle";
     $("preset").value = "";
+    for (const [id, value] of Object.entries(ADVANCED_DEFAULTS)) $(id).value = value;
+    syncLoadFactorOut();
     saveInputs();
     render();
   });

--- a/prop-motor-sizer/src/sizer-calculator.js
+++ b/prop-motor-sizer/src/sizer-calculator.js
@@ -358,7 +358,6 @@ export function analyze(inputs) {
     kv,
     cells,
     auwGrams,
-    motorCount = 4,
     capacityMah,
     measuredThrustG,
   } = inputs;
@@ -366,6 +365,10 @@ export function analyze(inputs) {
   const stator = parseMotorSize(inputs.motorSize);
 
   const has = (n) => typeof n === "number" && Number.isFinite(n) && n > 0;
+
+  // Used as a divisor throughout, so an explicit 0/negative/NaN from a
+  // programmatic caller must fall back to a quad rather than poison the math.
+  const motorCount = has(inputs.motorCount) ? Math.round(inputs.motorCount) : 4;
 
   const loadFactor = has(inputs.loadFactor) ? inputs.loadFactor : DEFAULT_LOAD_FACTOR;
   const cellVoltage = has(inputs.cellVoltage) ? inputs.cellVoltage : CELL_VOLTAGE_FULL;

--- a/prop-motor-sizer/src/sizer-calculator.js
+++ b/prop-motor-sizer/src/sizer-calculator.js
@@ -1,0 +1,572 @@
+/**
+ * Prop / motor sizing math. Pure functions, no DOM.
+ *
+ * All estimates use simplified physics (Staples static-thrust model,
+ * momentum theory for power) calibrated against typical FPV thrust-stand
+ * numbers. Treat outputs as ±20-30% ballparks, not bench data.
+ *
+ * Conventions: prop dimensions in inches, weights in grams, voltage at
+ * full charge (4.2 V/cell), RPM estimates assume props load the motor to
+ * ~75% of its unloaded KV×V ceiling.
+ */
+
+export const AIR_DENSITY = 1.225; // kg/m³, sea level
+export const SPEED_OF_SOUND = 343; // m/s
+export const IN_TO_M = 0.0254;
+export const CELL_VOLTAGE_FULL = 4.2;
+export const DEFAULT_LOAD_FACTOR = 0.75;
+
+const GRAMS_PER_NEWTON = 1000 / 9.81;
+
+// Thrust multiplier vs a 2-blade prop at the same RPM. Extra blades add
+// thrust with diminishing returns (and cost efficiency, handled elsewhere).
+const BLADE_FACTORS = { 2: 1.0, 3: 1.15, 4: 1.27, 5: 1.36, 6: 1.44 };
+
+// Stator volume (mm³) that suits a prop diameter d (inches) follows roughly
+// TARGET = STATOR_COEFF × d^STATOR_EXP, fitted to well-known pairings
+// (0802→1.2", 1404→3", 2207/2306→5", 2806.5→7"). The band multipliers set
+// how far off-center a pairing can be and still be listed as reasonable.
+const STATOR_COEFF = 67;
+const STATOR_EXP = 2.2;
+const STATOR_BAND = [0.6, 1.6];
+
+// Stator sizes commonly available off the shelf, used when recommending.
+const STANDARD_STATORS = [
+  "0802",
+  "0803",
+  "1002",
+  "1102",
+  "1103",
+  "1104",
+  "1202",
+  "1204",
+  "1303",
+  "1404",
+  "1406",
+  "1408",
+  "1504",
+  "1505",
+  "1506",
+  "1507",
+  "1606",
+  "1806",
+  "2004",
+  "2006",
+  "2205",
+  "2206",
+  "2207",
+  "2208",
+  "2306",
+  "2307",
+  "2405",
+  "2406",
+  "2407",
+  "2408",
+  "2506",
+  "2507",
+  "2508",
+  "2806",
+  "2806.5",
+  "2807",
+  "2808",
+  "3007",
+  "3110",
+  "3115",
+];
+
+// Pitch-to-diameter ratio bands per flying style.
+const PITCH_RATIOS = {
+  cinematic: [0.5, 0.75],
+  longrange: [0.55, 0.8],
+  freestyle: [0.7, 0.95],
+  racing: [0.8, 1.1],
+};
+
+// Thrust-to-weight bands per flying style, used to recommend AUW.
+const TWR_BANDS = {
+  cinematic: [2.5, 4.5],
+  longrange: [3, 6],
+  freestyle: [5, 10],
+  racing: [8, 16],
+};
+
+// Target KV is derived from an unloaded prop tip speed the class can use
+// well; smaller props run slower tips (lower Reynolds, weaker motors).
+const KV_STYLE_MULT = {
+  cinematic: 0.85,
+  longrange: 0.9,
+  freestyle: 1.0,
+  racing: 1.1,
+};
+const KV_BAND = 0.15; // ±15% around the ideal
+
+function normalizeStyle(style) {
+  return style in TWR_BANDS ? style : "freestyle";
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a motor stator size like "2207", "0802", or "2806.5".
+ * @param {unknown} value
+ * @returns {{statorDiameter: number, statorHeight: number} | null}
+ */
+export function parseMotorSize(value) {
+  const m = String(value ?? "").trim().match(/^(\d{2})[\sx-]?(\d{1,2}(?:\.\d)?)$/);
+  if (!m) return null;
+  const statorDiameter = Number(m[1]);
+  const statorHeight = Number(m[2]);
+  if (statorDiameter === 0 || statorHeight === 0) return null;
+  return { statorDiameter, statorHeight };
+}
+
+/**
+ * Stator volume in mm³, the usual proxy for torque capability.
+ * @param {{statorDiameter: number, statorHeight: number}} size
+ */
+export function statorVolume({ statorDiameter, statorHeight }) {
+  const r = statorDiameter / 2;
+  return Math.PI * r * r * statorHeight;
+}
+
+// ---------------------------------------------------------------------------
+// RPM and speeds
+// ---------------------------------------------------------------------------
+
+/** Unloaded RPM ceiling: KV × voltage. */
+export function maxRpm(kv, voltage) {
+  return kv * voltage;
+}
+
+/** Estimated RPM at full throttle under prop load. */
+export function loadedRpm(kv, voltage, loadFactor = DEFAULT_LOAD_FACTOR) {
+  return kv * voltage * loadFactor;
+}
+
+/** Prop tip speed in m/s at a given RPM. */
+export function tipSpeedMs(diameterIn, rpm) {
+  return Math.PI * diameterIn * IN_TO_M * (rpm / 60);
+}
+
+/** Fraction of the speed of sound. */
+export function machFraction(speedMs) {
+  return speedMs / SPEED_OF_SOUND;
+}
+
+/** Theoretical zero-slip forward speed in km/h. */
+export function pitchSpeedKmh(pitchIn, rpm) {
+  return pitchIn * IN_TO_M * (rpm / 60) * 3.6;
+}
+
+// ---------------------------------------------------------------------------
+// Thrust and power
+// ---------------------------------------------------------------------------
+
+function bladeFactor(blades) {
+  const b = Math.min(6, Math.max(2, Math.round(blades ?? 2)));
+  return BLADE_FACTORS[b];
+}
+
+/**
+ * Static thrust in grams-force for one prop, per the Staples model
+ * (calibrated for 2-blade props) with a blade-count multiplier.
+ * @param {number} diameterIn prop diameter, inches
+ * @param {number} pitchIn prop pitch, inches
+ * @param {number} rpm shaft speed under load
+ * @param {number} [blades]
+ */
+export function staticThrustGrams(diameterIn, pitchIn, rpm, blades = 2) {
+  const d = diameterIn * IN_TO_M;
+  const discArea = (Math.PI * d * d) / 4;
+  const exitVelocity = rpm * pitchIn * IN_TO_M / 60;
+  const slipFactor = Math.pow(diameterIn / (3.29546 * pitchIn), 1.5);
+  const newtons = AIR_DENSITY * discArea * exitVelocity * exitVelocity * slipFactor;
+  return newtons * bladeFactor(blades) * GRAMS_PER_NEWTON;
+}
+
+export function thrustToWeight(totalThrustGrams, auwGrams) {
+  return totalThrustGrams / auwGrams;
+}
+
+/**
+ * Hover throttle estimate in percent, assuming thrust ∝ throttle².
+ */
+export function hoverThrottlePercent(twr) {
+  return Math.sqrt(1 / twr) * 100;
+}
+
+/** All-up weight per unit of total disc area, in g/cm². */
+export function discLoading(auwGrams, diameterIn, motorCount) {
+  const radiusCm = (diameterIn * 2.54) / 2;
+  return auwGrams / (motorCount * Math.PI * radiusCm * radiusCm);
+}
+
+/**
+ * Electrical power (watts) to produce a given thrust on one prop, from
+ * momentum theory divided by a figure of merit and drive efficiency.
+ */
+export function electricalPowerWatts(
+  thrustGrams,
+  diameterIn,
+  figureOfMerit,
+  driveEfficiency = 0.85,
+) {
+  const thrustN = thrustGrams / GRAMS_PER_NEWTON;
+  const d = diameterIn * IN_TO_M;
+  const discArea = (Math.PI * d * d) / 4;
+  const idealWatts = Math.pow(thrustN, 1.5) / Math.sqrt(2 * AIR_DENSITY * discArea);
+  return idealWatts / (figureOfMerit * driveEfficiency);
+}
+
+// ---------------------------------------------------------------------------
+// Recommendations
+// ---------------------------------------------------------------------------
+
+/**
+ * Unloaded tip speed (m/s) a prop class can use well. Grows with diameter
+ * (tiny props can't reach the tip speeds a 5" runs) and saturates around
+ * the transonic-noise limit for big props.
+ */
+export function targetTipSpeed(diameterIn, style = "freestyle") {
+  const base = Math.min(320, Math.max(150, 120 + 36 * diameterIn));
+  return base * KV_STYLE_MULT[normalizeStyle(style)];
+}
+
+/**
+ * KV range for a prop diameter and (full-charge) voltage.
+ * @returns {{min: number, ideal: number, max: number}}
+ */
+export function recommendKv(diameterIn, voltage, style = "freestyle") {
+  const ideal = targetTipSpeed(diameterIn, style) /
+    (Math.PI * diameterIn * IN_TO_M * voltage / 60);
+  return {
+    min: Math.round(ideal * (1 - KV_BAND)),
+    ideal: Math.round(ideal),
+    max: Math.round(ideal * (1 + KV_BAND)),
+  };
+}
+
+/**
+ * Battery cell count for a prop diameter and motor KV.
+ * @returns {{min: number, ideal: number, max: number}}
+ */
+export function recommendCellCount(diameterIn, kv, style = "freestyle") {
+  const idealVoltage = targetTipSpeed(diameterIn, style) /
+    (Math.PI * diameterIn * IN_TO_M * kv / 60);
+  const toCells = (v) => Math.min(8, Math.max(1, Math.round(v / CELL_VOLTAGE_FULL)));
+  return {
+    min: toCells(idealVoltage * (1 - KV_BAND)),
+    ideal: toCells(idealVoltage),
+    max: toCells(idealVoltage * (1 + KV_BAND)),
+  };
+}
+
+/**
+ * Stator sizes whose volume suits a prop diameter.
+ * @returns {{targetVolume: number, sizes: string[]}}
+ */
+export function recommendMotorSizes(diameterIn) {
+  const targetVolume = STATOR_COEFF * Math.pow(diameterIn, STATOR_EXP);
+  const [lo, hi] = STATOR_BAND;
+  const sizes = STANDARD_STATORS.filter((s) => {
+    const vol = statorVolume(parseMotorSize(s));
+    return vol >= targetVolume * lo && vol <= targetVolume * hi;
+  });
+  return { targetVolume, sizes };
+}
+
+/**
+ * Prop diameter range that suits a motor size, inverting the stator fit.
+ * @returns {{min: number, ideal: number, max: number} | null}
+ */
+export function recommendPropDiameter(motorSize) {
+  const parsed = parseMotorSize(motorSize);
+  if (!parsed) return null;
+  const vol = statorVolume(parsed);
+  const toDiameter = (v) => Math.pow(v / STATOR_COEFF, 1 / STATOR_EXP);
+  const [lo, hi] = STATOR_BAND;
+  return {
+    min: round1(toDiameter(vol / hi)),
+    ideal: round1(toDiameter(vol)),
+    max: round1(toDiameter(vol / lo)),
+  };
+}
+
+/** Pitch range for a diameter and flying style. */
+export function recommendPitch(diameterIn, style = "freestyle") {
+  const [lo, hi] = PITCH_RATIOS[normalizeStyle(style)];
+  return { min: round1(diameterIn * lo), max: round1(diameterIn * hi) };
+}
+
+/** AUW range that puts total thrust in the style's thrust-to-weight band. */
+export function recommendAuw(totalThrustGrams, style = "freestyle") {
+  const [lo, hi] = TWR_BANDS[normalizeStyle(style)];
+  return {
+    min: Math.round(totalThrustGrams / hi),
+    max: Math.round(totalThrustGrams / lo),
+  };
+}
+
+function round1(n) {
+  return Math.round(n * 10) / 10;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute every metric, recommendation, and verdict the given (possibly
+ * partial) inputs allow.
+ *
+ * @param {{
+ *   diameterIn?: number, pitchIn?: number, blades?: number,
+ *   motorSize?: string, kv?: number, cells?: number, auwGrams?: number,
+ *   motorCount?: number, style?: string,
+ * }} inputs
+ * @returns {{metrics: object, recommendations: object, verdicts: Array<{level: string, text: string}>}}
+ */
+export function analyze(inputs) {
+  const {
+    diameterIn,
+    pitchIn,
+    blades = 3,
+    kv,
+    cells,
+    auwGrams,
+    motorCount = 4,
+  } = inputs;
+  const style = normalizeStyle(inputs.style);
+  const stator = parseMotorSize(inputs.motorSize);
+
+  const has = (n) => typeof n === "number" && Number.isFinite(n) && n > 0;
+
+  const metrics = {};
+  const recommendations = {};
+  const verdicts = [];
+
+  if (stator) metrics.statorVolumeMm3 = statorVolume(stator);
+  if (has(cells)) metrics.voltage = cells * CELL_VOLTAGE_FULL;
+
+  if (has(kv) && has(cells)) {
+    metrics.maxRpm = maxRpm(kv, metrics.voltage);
+    metrics.loadedRpm = loadedRpm(kv, metrics.voltage);
+  }
+
+  if (has(diameterIn) && has(metrics.loadedRpm)) {
+    metrics.tipSpeedMs = tipSpeedMs(diameterIn, metrics.loadedRpm);
+    metrics.tipMach = machFraction(metrics.tipSpeedMs);
+  }
+
+  if (has(pitchIn) && has(metrics.loadedRpm)) {
+    metrics.pitchSpeedKmh = pitchSpeedKmh(pitchIn, metrics.loadedRpm);
+    metrics.pitchSpeedMph = metrics.pitchSpeedKmh / 1.609344;
+  }
+
+  if (has(diameterIn) && has(pitchIn) && has(metrics.loadedRpm)) {
+    metrics.thrustPerMotorG = staticThrustGrams(diameterIn, pitchIn, metrics.loadedRpm, blades);
+    metrics.totalThrustG = metrics.thrustPerMotorG * motorCount;
+    metrics.maxPowerW = electricalPowerWatts(metrics.thrustPerMotorG, diameterIn, 0.55) *
+      motorCount;
+    metrics.maxCurrentA = metrics.maxPowerW / metrics.voltage;
+    metrics.maxCurrentPerMotorA = metrics.maxCurrentA / motorCount;
+  }
+
+  if (has(auwGrams) && has(metrics.totalThrustG)) {
+    metrics.twr = thrustToWeight(metrics.totalThrustG, auwGrams);
+    metrics.hoverThrottlePct = hoverThrottlePercent(metrics.twr);
+  }
+
+  if (has(auwGrams) && has(diameterIn)) {
+    metrics.discLoadingGCm2 = discLoading(auwGrams, diameterIn, motorCount);
+    if (has(metrics.voltage)) {
+      metrics.hoverPowerW = electricalPowerWatts(auwGrams / motorCount, diameterIn, 0.65) *
+        motorCount;
+      metrics.hoverCurrentA = metrics.hoverPowerW / metrics.voltage;
+    }
+  }
+
+  // --- Recommendations for whatever was left unset -------------------------
+
+  if (!has(kv) && has(diameterIn) && has(cells)) {
+    recommendations.kv = {
+      ...recommendKv(diameterIn, metrics.voltage, style),
+      basis: `${diameterIn}″ prop at ${cells}S`,
+    };
+  }
+
+  if (!has(cells) && has(diameterIn) && has(kv)) {
+    recommendations.cells = {
+      ...recommendCellCount(diameterIn, kv, style),
+      basis: `${diameterIn}″ prop at ${kv}KV`,
+    };
+  }
+
+  if (!stator && has(diameterIn)) {
+    recommendations.motorSizes = {
+      ...recommendMotorSizes(diameterIn),
+      basis: `${diameterIn}″ prop`,
+    };
+  }
+
+  if (!has(diameterIn) && stator) {
+    recommendations.diameter = {
+      ...recommendPropDiameter(inputs.motorSize),
+      basis: `${inputs.motorSize} stator`,
+    };
+  }
+
+  if (!has(pitchIn) && has(diameterIn)) {
+    recommendations.pitch = {
+      ...recommendPitch(diameterIn, style),
+      basis: `${diameterIn}″ prop, ${style}`,
+    };
+  }
+
+  if (!has(auwGrams) && has(metrics.totalThrustG)) {
+    recommendations.auw = {
+      ...recommendAuw(metrics.totalThrustG, style),
+      basis: `${Math.round(metrics.totalThrustG)}g total thrust, ${style}`,
+    };
+  }
+
+  // --- Verdicts ------------------------------------------------------------
+
+  if (has(metrics.twr)) {
+    const twr = metrics.twr;
+    if (twr < 1.3) {
+      verdicts.push({
+        level: "bad",
+        text: `Thrust-to-weight ${
+          twr.toFixed(1)
+        }:1 — not enough thrust to hover reliably. This won't fly.`,
+      });
+    } else if (twr < 2.5) {
+      verdicts.push({
+        level: "warn",
+        text: `Thrust-to-weight ${
+          twr.toFixed(1)
+        }:1 — very heavily loaded. Sluggish; only workable for heavy-lift or cinelifter duty.`,
+      });
+    } else if (twr < 5) {
+      verdicts.push({
+        level: "good",
+        text: `Thrust-to-weight ${
+          twr.toFixed(1)
+        }:1 — smooth and efficient. Cinematic or long-range cruising territory.`,
+      });
+    } else if (twr < 8) {
+      verdicts.push({
+        level: "good",
+        text: `Thrust-to-weight ${
+          twr.toFixed(1)
+        }:1 — relaxed freestyle. Playful with reasonable flight times.`,
+      });
+    } else if (twr < 13) {
+      verdicts.push({
+        level: "good",
+        text: `Thrust-to-weight ${
+          twr.toFixed(1)
+        }:1 — modern freestyle sweet spot. Plenty of punch for tricks and race-capable.`,
+      });
+    } else {
+      verdicts.push({
+        level: "info",
+        text: `Thrust-to-weight ${
+          twr.toFixed(1)
+        }:1 — race-spec violence. Demands throttle discipline; expect short flights.`,
+      });
+    }
+  }
+
+  if (has(metrics.tipMach)) {
+    if (metrics.tipMach > 0.85) {
+      verdicts.push({
+        level: "warn",
+        text: `Prop tips reach Mach ${
+          metrics.tipMach.toFixed(2)
+        } at full throttle — transonic tips are loud, inefficient, and hard on props. Consider lower KV, fewer cells, or a smaller prop.`,
+      });
+    } else if (metrics.tipMach > 0.7) {
+      verdicts.push({
+        level: "info",
+        text: `Prop tips reach Mach ${
+          metrics.tipMach.toFixed(2)
+        } at full throttle — on the loud side, typical of aggressive builds.`,
+      });
+    }
+  }
+
+  if (has(metrics.hoverThrottlePct)) {
+    if (metrics.hoverThrottlePct > 45) {
+      verdicts.push({
+        level: "warn",
+        text: `Hovering near ${
+          Math.round(metrics.hoverThrottlePct)
+        }% throttle leaves little headroom for climbing or stopping a descent.`,
+      });
+    }
+  }
+
+  if (stator && has(diameterIn)) {
+    const target = STATOR_COEFF * Math.pow(diameterIn, STATOR_EXP);
+    const ratio = statorVolume(stator) / target;
+    if (ratio < 0.6) {
+      verdicts.push({
+        level: "bad",
+        text:
+          `Motor looks undersized for a ${diameterIn}″ prop — expect bogging in hard maneuvers, hot motors, and mushy response.`,
+      });
+    } else if (ratio < 0.8) {
+      verdicts.push({
+        level: "warn",
+        text:
+          `Motor is on the small side for a ${diameterIn}″ prop — fine for light, efficient builds; may run warm when pushed.`,
+      });
+    } else if (ratio <= 1.3) {
+      verdicts.push({
+        level: "good",
+        text: `Motor size is well matched to a ${diameterIn}″ prop.`,
+      });
+    } else if (ratio <= 1.8) {
+      verdicts.push({
+        level: "info",
+        text:
+          `Motor has torque to spare for a ${diameterIn}″ prop — authoritative, at the cost of some weight.`,
+      });
+    } else {
+      verdicts.push({
+        level: "warn",
+        text:
+          `Motor looks oversized for a ${diameterIn}″ prop — you're carrying motor weight the prop can't use.`,
+      });
+    }
+  }
+
+  if (has(kv) && has(cells) && has(diameterIn)) {
+    const ideal = recommendKv(diameterIn, metrics.voltage, style).ideal;
+    const ratio = kv / ideal;
+    if (ratio > 1.25) {
+      verdicts.push({
+        level: "warn",
+        text:
+          `${kv}KV on ${cells}S over-revs a ${diameterIn}″ prop (ideal ≈ ${ideal}KV) — expect high current draw and heat.`,
+      });
+    } else if (ratio < 0.75) {
+      verdicts.push({
+        level: "warn",
+        text:
+          `${kv}KV on ${cells}S under-revs a ${diameterIn}″ prop (ideal ≈ ${ideal}KV) — soft top end; efficient but slow.`,
+      });
+    } else {
+      verdicts.push({
+        level: "good",
+        text: `${kv}KV is well matched to a ${diameterIn}″ prop on ${cells}S.`,
+      });
+    }
+  }
+
+  return { metrics, recommendations, verdicts };
+}

--- a/prop-motor-sizer/src/sizer-calculator.js
+++ b/prop-motor-sizer/src/sizer-calculator.js
@@ -14,7 +14,9 @@ export const AIR_DENSITY = 1.225; // kg/m³, sea level
 export const SPEED_OF_SOUND = 343; // m/s
 export const IN_TO_M = 0.0254;
 export const CELL_VOLTAGE_FULL = 4.2;
+export const CELL_VOLTAGE_NOMINAL = 3.7;
 export const DEFAULT_LOAD_FACTOR = 0.75;
+export const USABLE_BATTERY_FRACTION = 0.8;
 
 const GRAMS_PER_NEWTON = 1000 / 9.81;
 
@@ -145,6 +147,15 @@ export function loadedRpm(kv, voltage, loadFactor = DEFAULT_LOAD_FACTOR) {
   return kv * voltage * loadFactor;
 }
 
+/**
+ * Air density (kg/m³) at an altitude in meters, per the standard-atmosphere
+ * troposphere model. Missing or negative altitudes read as sea level.
+ */
+export function airDensityAtAltitude(altitudeM) {
+  const h = Math.min(11000, Math.max(0, altitudeM ?? 0));
+  return AIR_DENSITY * Math.pow(1 - 2.25577e-5 * h, 4.2561);
+}
+
 /** Prop tip speed in m/s at a given RPM. */
 export function tipSpeedMs(diameterIn, rpm) {
   return Math.PI * diameterIn * IN_TO_M * (rpm / 60);
@@ -176,13 +187,14 @@ function bladeFactor(blades) {
  * @param {number} pitchIn prop pitch, inches
  * @param {number} rpm shaft speed under load
  * @param {number} [blades]
+ * @param {number} [density] air density, kg/m³
  */
-export function staticThrustGrams(diameterIn, pitchIn, rpm, blades = 2) {
+export function staticThrustGrams(diameterIn, pitchIn, rpm, blades = 2, density = AIR_DENSITY) {
   const d = diameterIn * IN_TO_M;
   const discArea = (Math.PI * d * d) / 4;
   const exitVelocity = rpm * pitchIn * IN_TO_M / 60;
   const slipFactor = Math.pow(diameterIn / (3.29546 * pitchIn), 1.5);
-  const newtons = AIR_DENSITY * discArea * exitVelocity * exitVelocity * slipFactor;
+  const newtons = density * discArea * exitVelocity * exitVelocity * slipFactor;
   return newtons * bladeFactor(blades) * GRAMS_PER_NEWTON;
 }
 
@@ -212,11 +224,12 @@ export function electricalPowerWatts(
   diameterIn,
   figureOfMerit,
   driveEfficiency = 0.85,
+  density = AIR_DENSITY,
 ) {
   const thrustN = thrustGrams / GRAMS_PER_NEWTON;
   const d = diameterIn * IN_TO_M;
   const discArea = (Math.PI * d * d) / 4;
-  const idealWatts = Math.pow(thrustN, 1.5) / Math.sqrt(2 * AIR_DENSITY * discArea);
+  const idealWatts = Math.pow(thrustN, 1.5) / Math.sqrt(2 * density * discArea);
   return idealWatts / (figureOfMerit * driveEfficiency);
 }
 
@@ -321,10 +334,19 @@ function round1(n) {
  * Compute every metric, recommendation, and verdict the given (possibly
  * partial) inputs allow.
  *
+ * Advanced inputs (all optional): `loadFactor` overrides the 75% loaded-RPM
+ * assumption; `cellVoltage` sets the per-cell voltage metrics are computed at
+ * (recommendations always use `cellVoltageFull`, the community's full-charge
+ * KV convention); `altitudeM` derates air density; `capacityMah` (with
+ * `cellVoltageNominal` for energy) enables a hover-endurance estimate; and
+ * `measuredThrustG` rescales the thrust model to a bench-tested value.
+ *
  * @param {{
  *   diameterIn?: number, pitchIn?: number, blades?: number,
  *   motorSize?: string, kv?: number, cells?: number, auwGrams?: number,
- *   motorCount?: number, style?: string,
+ *   motorCount?: number, style?: string, loadFactor?: number,
+ *   cellVoltage?: number, cellVoltageFull?: number, cellVoltageNominal?: number,
+ *   altitudeM?: number, capacityMah?: number, measuredThrustG?: number,
  * }} inputs
  * @returns {{metrics: object, recommendations: object, verdicts: Array<{level: string, text: string}>}}
  */
@@ -337,22 +359,33 @@ export function analyze(inputs) {
     cells,
     auwGrams,
     motorCount = 4,
+    capacityMah,
+    measuredThrustG,
   } = inputs;
   const style = normalizeStyle(inputs.style);
   const stator = parseMotorSize(inputs.motorSize);
 
   const has = (n) => typeof n === "number" && Number.isFinite(n) && n > 0;
 
+  const loadFactor = has(inputs.loadFactor) ? inputs.loadFactor : DEFAULT_LOAD_FACTOR;
+  const cellVoltage = has(inputs.cellVoltage) ? inputs.cellVoltage : CELL_VOLTAGE_FULL;
+  const cellVoltageFull = has(inputs.cellVoltageFull) ? inputs.cellVoltageFull : CELL_VOLTAGE_FULL;
+  const cellVoltageNominal = has(inputs.cellVoltageNominal)
+    ? inputs.cellVoltageNominal
+    : CELL_VOLTAGE_NOMINAL;
+  const density = airDensityAtAltitude(inputs.altitudeM);
+
   const metrics = {};
   const recommendations = {};
   const verdicts = [];
 
   if (stator) metrics.statorVolumeMm3 = statorVolume(stator);
-  if (has(cells)) metrics.voltage = cells * CELL_VOLTAGE_FULL;
+  if (has(cells)) metrics.voltage = cells * cellVoltage;
+  if (has(inputs.altitudeM)) metrics.airDensity = density;
 
   if (has(kv) && has(cells)) {
     metrics.maxRpm = maxRpm(kv, metrics.voltage);
-    metrics.loadedRpm = loadedRpm(kv, metrics.voltage);
+    metrics.loadedRpm = loadedRpm(kv, metrics.voltage, loadFactor);
   }
 
   if (has(diameterIn) && has(metrics.loadedRpm)) {
@@ -366,9 +399,20 @@ export function analyze(inputs) {
   }
 
   if (has(diameterIn) && has(pitchIn) && has(metrics.loadedRpm)) {
-    metrics.thrustPerMotorG = staticThrustGrams(diameterIn, pitchIn, metrics.loadedRpm, blades);
+    metrics.thrustPerMotorG = staticThrustGrams(
+      diameterIn,
+      pitchIn,
+      metrics.loadedRpm,
+      blades,
+      density,
+    );
+    if (has(measuredThrustG)) {
+      metrics.calibrationFactor = measuredThrustG / metrics.thrustPerMotorG;
+      metrics.thrustPerMotorG = measuredThrustG;
+    }
     metrics.totalThrustG = metrics.thrustPerMotorG * motorCount;
-    metrics.maxPowerW = electricalPowerWatts(metrics.thrustPerMotorG, diameterIn, 0.55) *
+    metrics.maxPowerW =
+      electricalPowerWatts(metrics.thrustPerMotorG, diameterIn, 0.55, 0.85, density) *
       motorCount;
     metrics.maxCurrentA = metrics.maxPowerW / metrics.voltage;
     metrics.maxCurrentPerMotorA = metrics.maxCurrentA / motorCount;
@@ -382,9 +426,15 @@ export function analyze(inputs) {
   if (has(auwGrams) && has(diameterIn)) {
     metrics.discLoadingGCm2 = discLoading(auwGrams, diameterIn, motorCount);
     if (has(metrics.voltage)) {
-      metrics.hoverPowerW = electricalPowerWatts(auwGrams / motorCount, diameterIn, 0.65) *
+      metrics.hoverPowerW =
+        electricalPowerWatts(auwGrams / motorCount, diameterIn, 0.65, 0.85, density) *
         motorCount;
       metrics.hoverCurrentA = metrics.hoverPowerW / metrics.voltage;
+      if (has(capacityMah) && has(cells)) {
+        const energyWh = (capacityMah / 1000) * cells * cellVoltageNominal;
+        metrics.hoverFlightTimeMin = (energyWh * USABLE_BATTERY_FRACTION) /
+          metrics.hoverPowerW * 60;
+      }
     }
   }
 
@@ -392,7 +442,7 @@ export function analyze(inputs) {
 
   if (!has(kv) && has(diameterIn) && has(cells)) {
     recommendations.kv = {
-      ...recommendKv(diameterIn, metrics.voltage, style),
+      ...recommendKv(diameterIn, cells * cellVoltageFull, style),
       basis: `${diameterIn}″ prop at ${cells}S`,
     };
   }
@@ -545,8 +595,19 @@ export function analyze(inputs) {
     }
   }
 
+  if (has(metrics.calibrationFactor)) {
+    const factor = metrics.calibrationFactor;
+    const divergent = factor < 0.7 || factor > 1.4;
+    verdicts.push({
+      level: divergent ? "warn" : "info",
+      text: `Thrust model calibrated ×${factor.toFixed(2)} to your measured ${
+        Math.round(measuredThrustG)
+      }g/motor${divergent ? " — the model diverges a lot here, trust the bench numbers" : ""}.`,
+    });
+  }
+
   if (has(kv) && has(cells) && has(diameterIn)) {
-    const ideal = recommendKv(diameterIn, metrics.voltage, style).ideal;
+    const ideal = recommendKv(diameterIn, cells * cellVoltageFull, style).ideal;
     const ratio = kv / ideal;
     if (ratio > 1.25) {
       verdicts.push({

--- a/prop-motor-sizer/src/sizer-calculator.js
+++ b/prop-motor-sizer/src/sizer-calculator.js
@@ -427,11 +427,12 @@ export function analyze(inputs) {
   }
 
   if (has(auwGrams) && has(diameterIn)) {
-    metrics.discLoadingGCm2 = discLoading(auwGrams, diameterIn, motorCount);
+    const motors = has(motorCount) ? motorCount : 4;
+    metrics.discLoadingGCm2 = discLoading(auwGrams, diameterIn, motors);
     if (has(metrics.voltage)) {
       metrics.hoverPowerW =
-        electricalPowerWatts(auwGrams / motorCount, diameterIn, 0.65, 0.85, density) *
-        motorCount;
+        electricalPowerWatts(auwGrams / motors, diameterIn, 0.65, 0.85, density) *
+        motors;
       metrics.hoverCurrentA = metrics.hoverPowerW / metrics.voltage;
       if (has(capacityMah) && has(cells)) {
         const energyWh = (capacityMah / 1000) * cells * cellVoltageNominal;

--- a/prop-motor-sizer/src/sizer-calculator.js
+++ b/prop-motor-sizer/src/sizer-calculator.js
@@ -402,6 +402,7 @@ export function analyze(inputs) {
   }
 
   if (has(diameterIn) && has(pitchIn) && has(metrics.loadedRpm)) {
+    const motors = has(motorCount) ? motorCount : 4;
     metrics.thrustPerMotorG = staticThrustGrams(
       diameterIn,
       pitchIn,
@@ -413,12 +414,12 @@ export function analyze(inputs) {
       metrics.calibrationFactor = measuredThrustG / metrics.thrustPerMotorG;
       metrics.thrustPerMotorG = measuredThrustG;
     }
-    metrics.totalThrustG = metrics.thrustPerMotorG * motorCount;
+    metrics.totalThrustG = metrics.thrustPerMotorG * motors;
     metrics.maxPowerW =
       electricalPowerWatts(metrics.thrustPerMotorG, diameterIn, 0.55, 0.85, density) *
-      motorCount;
+      motors;
     metrics.maxCurrentA = metrics.maxPowerW / metrics.voltage;
-    metrics.maxCurrentPerMotorA = metrics.maxCurrentA / motorCount;
+    metrics.maxCurrentPerMotorA = metrics.maxCurrentA / motors;
   }
 
   if (has(auwGrams) && has(metrics.totalThrustG)) {

--- a/prop-motor-sizer/styles.css
+++ b/prop-motor-sizer/styles.css
@@ -1,0 +1,270 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --bg-dark: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #1a1f26;
+  --border-color: #30363d;
+  --text-primary: #c9d1d9;
+  --text-secondary: #8b949e;
+  --text-muted: #6e7681;
+  --orange: #e07b39;
+
+  --color-good: #3fb950;
+  --color-info: #58a6ff;
+  --color-warn: #d29922;
+  --color-bad: #f85149;
+
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial,
+    sans-serif;
+  background-color: var(--bg-dark);
+  color: var(--text-primary);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--spacing-xl) var(--spacing-md);
+}
+
+.sizer-layout {
+  display: grid;
+  grid-template-columns: minmax(300px, 380px) 1fr;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+
+@media (max-width: 800px) {
+  .sizer-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.panel {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: var(--spacing-lg);
+}
+
+.panel h2 {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: var(--spacing-sm);
+}
+
+.panel h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--orange);
+  margin: var(--spacing-md) 0 var(--spacing-xs);
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-sm);
+}
+
+/* Inputs */
+
+.field-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+.field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.field em {
+  font-style: normal;
+  color: var(--text-muted);
+}
+
+.field input,
+.field select {
+  width: 100%;
+  background-color: var(--bg-dark);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9rem;
+  padding: 0.45rem 0.55rem;
+  min-height: 40px;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: var(--orange);
+}
+
+.field input::placeholder {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.actions {
+  margin-top: var(--spacing-md);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn-secondary {
+  background-color: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.4rem 0.9rem;
+  min-height: 40px;
+}
+
+.btn-secondary:hover {
+  border-color: var(--text-muted);
+  color: var(--text-primary);
+}
+
+/* Results */
+
+.results-panel > div + div {
+  margin-top: var(--spacing-lg);
+}
+
+.empty-state {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  padding: var(--spacing-md) 0;
+}
+
+.verdicts {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.verdicts li {
+  border-left: 3px solid var(--text-muted);
+  background-color: var(--bg-tertiary);
+  border-radius: 0 6px 6px 0;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: 0.85rem;
+}
+
+.verdicts li.good {
+  border-left-color: var(--color-good);
+}
+.verdicts li.info {
+  border-left-color: var(--color-info);
+}
+.verdicts li.warn {
+  border-left-color: var(--color-warn);
+}
+.verdicts li.bad {
+  border-left-color: var(--color-bad);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: var(--spacing-sm);
+}
+
+.metric {
+  background-color: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.metric .metric-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.metric .metric-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+}
+
+.metric .metric-sub {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.metric.highlight {
+  border-color: var(--orange);
+}
+
+.metric.highlight .metric-value {
+  color: var(--orange);
+  font-size: 1.3rem;
+}
+
+.recs {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.recs li {
+  background-color: var(--bg-tertiary);
+  border: 1px dashed var(--border-color);
+  border-radius: 6px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: 0.85rem;
+}
+
+.recs .rec-field {
+  color: var(--orange);
+  font-weight: 600;
+}
+
+.recs .rec-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.recs .rec-basis {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.disclaimer {
+  margin-top: var(--spacing-lg);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border-color);
+  padding-top: var(--spacing-sm);
+}

--- a/prop-motor-sizer/styles.css
+++ b/prop-motor-sizer/styles.css
@@ -129,6 +129,33 @@ body {
   font-style: italic;
 }
 
+.advanced {
+  margin-top: var(--spacing-md);
+  border-top: 1px solid var(--border-color);
+  padding-top: var(--spacing-sm);
+}
+
+.advanced summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-sm);
+  user-select: none;
+}
+
+.advanced summary:hover {
+  color: var(--orange);
+}
+
+.field input[type='range'] {
+  min-height: 40px;
+  padding: 0;
+  accent-color: var(--orange);
+  border: none;
+  background: transparent;
+}
+
 .actions {
   margin-top: var(--spacing-md);
   display: flex;

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // Bump CACHE_NAME whenever the precache list below changes so clients
 // pick up the new set instead of serving a stale mix.
 const CACHE_PREFIX = "fpv-tools-";
-const CACHE_NAME = `${CACHE_PREFIX}v1`;
+const CACHE_NAME = `${CACHE_PREFIX}v2`;
 
 // Cross-origin hosts we deliberately cache for offline use (e.g. the IGOW
 // tool loads sql.js from here). Anything else cross-origin is passed
@@ -41,6 +41,11 @@ const PRECACHE_URLS = [
   "./igow/",
   "./igow/index.html",
   "./igow/igow.db",
+  "./prop-motor-sizer/",
+  "./prop-motor-sizer/index.html",
+  "./prop-motor-sizer/styles.css",
+  "./prop-motor-sizer/src/app.js",
+  "./prop-motor-sizer/src/sizer-calculator.js",
 ];
 
 self.addEventListener("install", (event) => {

--- a/tests/prop-motor-sizer/sizer-calculator.test.ts
+++ b/tests/prop-motor-sizer/sizer-calculator.test.ts
@@ -4,6 +4,8 @@ import {
   assertEquals,
 } from "https://deno.land/std@0.208.0/assert/mod.ts";
 import {
+  AIR_DENSITY,
+  airDensityAtAltitude,
   analyze,
   discLoading,
   hoverThrottlePercent,
@@ -277,4 +279,97 @@ Deno.test("analyze - empty input does not throw", () => {
   assertEquals(Object.keys(metrics).length, 0);
   assertEquals(Object.keys(recommendations).length, 0);
   assertEquals(verdicts.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Advanced mode - altitude / air density
+// ---------------------------------------------------------------------------
+
+Deno.test("airDensityAtAltitude - sea level matches the standard constant", () => {
+  assertAlmostEquals(airDensityAtAltitude(0), AIR_DENSITY, 1e-9);
+});
+
+Deno.test("airDensityAtAltitude - 2000m is about 18% thinner", () => {
+  assertAlmostEquals(airDensityAtAltitude(2000), 1.007, 0.01);
+});
+
+Deno.test("airDensityAtAltitude - negative or missing altitude clamps to sea level", () => {
+  assertAlmostEquals(airDensityAtAltitude(-100), AIR_DENSITY, 1e-9);
+  assertAlmostEquals(airDensityAtAltitude(undefined), AIR_DENSITY, 1e-9);
+});
+
+Deno.test("staticThrustGrams - thrust scales linearly with air density", () => {
+  const seaLevel = staticThrustGrams(5, 4.5, 30000, 3);
+  const thin = staticThrustGrams(5, 4.5, 30000, 3, 1.0);
+  assertAlmostEquals(thin / seaLevel, 1.0 / AIR_DENSITY, 1e-9);
+});
+
+Deno.test("analyze - altitude derates thrust", () => {
+  const seaLevel = analyze(FULL_5IN_6S).metrics;
+  const at2000 = analyze({ ...FULL_5IN_6S, altitudeM: 2000 }).metrics;
+  const ratio = at2000.totalThrustG / seaLevel.totalThrustG;
+  assert(ratio > 0.8 && ratio < 0.84, `ratio ${ratio}`);
+});
+
+// ---------------------------------------------------------------------------
+// Advanced mode - load factor and voltage basis
+// ---------------------------------------------------------------------------
+
+Deno.test("analyze - custom load factor moves loaded RPM", () => {
+  const { metrics } = analyze({ ...FULL_5IN_6S, loadFactor: 0.85 });
+  assertAlmostEquals(metrics.loadedRpm, 1800 * 25.2 * 0.85, 1e-6);
+});
+
+Deno.test("analyze - per-cell voltage changes metrics but not recommendations", () => {
+  // Metrics at nominal 3.7V/cell; KV recommendations stay on the full-charge
+  // convention so they match how the community quotes KV.
+  const { metrics, recommendations } = analyze({
+    diameterIn: 5,
+    cells: 6,
+    blades: 3,
+    motorCount: 4,
+    style: "freestyle",
+    cellVoltage: 3.7,
+  });
+  assertAlmostEquals(metrics.voltage, 22.2, 1e-9);
+  assert(
+    recommendations.kv.ideal > 1600 && recommendations.kv.ideal < 2000,
+    `ideal ${recommendations.kv.ideal}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Advanced mode - battery capacity and hover endurance
+// ---------------------------------------------------------------------------
+
+Deno.test("analyze - battery capacity yields a plausible hover endurance", () => {
+  const { metrics } = analyze({ ...FULL_5IN_6S, capacityMah: 1300 });
+  assert(
+    metrics.hoverFlightTimeMin > 8 && metrics.hoverFlightTimeMin < 25,
+    `endurance ${metrics.hoverFlightTimeMin}`,
+  );
+});
+
+Deno.test("analyze - no capacity means no endurance metric", () => {
+  assertEquals(analyze(FULL_5IN_6S).metrics.hoverFlightTimeMin, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Advanced mode - thrust-stand calibration
+// ---------------------------------------------------------------------------
+
+Deno.test("analyze - measured thrust calibrates the model", () => {
+  const { metrics } = analyze({ ...FULL_5IN_6S, measuredThrustG: 1650 });
+  assertAlmostEquals(metrics.thrustPerMotorG, 1650, 1e-9);
+  assertAlmostEquals(metrics.totalThrustG, 6600, 1e-9);
+  assertAlmostEquals(metrics.twr, 6600 / 650, 1e-9);
+  assert(
+    metrics.calibrationFactor > 1.0 && metrics.calibrationFactor < 1.2,
+    `factor ${metrics.calibrationFactor}`,
+  );
+});
+
+Deno.test("analyze - calibration adds an info verdict", () => {
+  const { verdicts } = analyze({ ...FULL_5IN_6S, measuredThrustG: 1650 });
+  assert(verdicts.some((v: { text: string }) => v.text.includes("alibrat")));
 });

--- a/tests/prop-motor-sizer/sizer-calculator.test.ts
+++ b/tests/prop-motor-sizer/sizer-calculator.test.ts
@@ -274,6 +274,17 @@ Deno.test("analyze - grossly overloaded build gets a 'bad' verdict", () => {
   assert(verdicts.some((v: { level: string }) => v.level === "bad"));
 });
 
+Deno.test("analyze - zero or invalid motor count falls back to a quad", () => {
+  const base = analyze(FULL_5IN_6S).metrics;
+  for (const motorCount of [0, -2, NaN]) {
+    const m = analyze({ ...FULL_5IN_6S, motorCount }).metrics;
+    assertAlmostEquals(m.totalThrustG, base.totalThrustG, 1e-9);
+    assertAlmostEquals(m.discLoadingGCm2, base.discLoadingGCm2, 1e-9);
+    assert(Number.isFinite(m.maxCurrentPerMotorA), `per-motor current for count ${motorCount}`);
+    assert(Number.isFinite(m.hoverCurrentA), `hover current for count ${motorCount}`);
+  }
+});
+
 Deno.test("analyze - empty input does not throw", () => {
   const { metrics, recommendations, verdicts } = analyze({});
   assertEquals(Object.keys(metrics).length, 0);

--- a/tests/prop-motor-sizer/sizer-calculator.test.ts
+++ b/tests/prop-motor-sizer/sizer-calculator.test.ts
@@ -232,7 +232,9 @@ Deno.test("analyze - full 5-inch 6S freestyle build produces sane metrics", () =
   assert(metrics.twr > 7 && metrics.twr < 12, `twr ${metrics.twr}`);
   assert(metrics.hoverThrottlePct > 25 && metrics.hoverThrottlePct < 40);
   assert(metrics.tipMach > 0.5 && metrics.tipMach < 0.8);
-  assert(metrics.maxCurrentA > 15 && metrics.maxCurrentA < 45);
+  // Per-motor max draw ~25-35A and total ~80-140A are typical for this class
+  assert(metrics.maxCurrentPerMotorA > 15 && metrics.maxCurrentPerMotorA < 45);
+  assert(metrics.maxCurrentA > 60 && metrics.maxCurrentA < 180);
   // Everything was specified, so nothing to recommend
   assertEquals(Object.keys(recommendations).length, 0);
   assert(verdicts.length > 0);

--- a/tests/prop-motor-sizer/sizer-calculator.test.ts
+++ b/tests/prop-motor-sizer/sizer-calculator.test.ts
@@ -1,0 +1,278 @@
+import {
+  assert,
+  assertAlmostEquals,
+  assertEquals,
+} from "https://deno.land/std@0.208.0/assert/mod.ts";
+import {
+  analyze,
+  discLoading,
+  hoverThrottlePercent,
+  loadedRpm,
+  maxRpm,
+  parseMotorSize,
+  pitchSpeedKmh,
+  recommendAuw,
+  recommendCellCount,
+  recommendKv,
+  recommendMotorSizes,
+  recommendPitch,
+  recommendPropDiameter,
+  staticThrustGrams,
+  statorVolume,
+  thrustToWeight,
+  tipSpeedMs,
+} from "../../prop-motor-sizer/src/sizer-calculator.js";
+
+// ---------------------------------------------------------------------------
+// Motor size parsing
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMotorSize - standard four-digit size", () => {
+  assertEquals(parseMotorSize("2207"), { statorDiameter: 22, statorHeight: 7 });
+});
+
+Deno.test("parseMotorSize - leading-zero whoop size", () => {
+  assertEquals(parseMotorSize("0802"), { statorDiameter: 8, statorHeight: 2 });
+});
+
+Deno.test("parseMotorSize - decimal stator height", () => {
+  assertEquals(parseMotorSize("2806.5"), { statorDiameter: 28, statorHeight: 6.5 });
+});
+
+Deno.test("parseMotorSize - garbage returns null", () => {
+  assertEquals(parseMotorSize("not a motor"), null);
+  assertEquals(parseMotorSize(""), null);
+  assertEquals(parseMotorSize(null), null);
+});
+
+Deno.test("statorVolume - cylinder volume in mm³", () => {
+  // 2207: π × 11² × 7
+  assertAlmostEquals(
+    statorVolume({ statorDiameter: 22, statorHeight: 7 }),
+    Math.PI * 11 * 11 * 7,
+    0.1,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// RPM and speeds
+// ---------------------------------------------------------------------------
+
+Deno.test("maxRpm - KV times voltage", () => {
+  assertEquals(maxRpm(1800, 25.2), 45360);
+});
+
+Deno.test("loadedRpm - default load factor is 75% of unloaded", () => {
+  assertAlmostEquals(loadedRpm(1800, 25.2), 34020, 1e-6);
+});
+
+Deno.test("tipSpeedMs - circumference times revs per second", () => {
+  // 5" prop at 34020 RPM: π × (5 × 0.0254) × 34020/60
+  assertAlmostEquals(tipSpeedMs(5, 34020), Math.PI * 5 * 0.0254 * 567, 1e-6);
+});
+
+Deno.test("pitchSpeedKmh - pitch advance per rev", () => {
+  // 4.5" pitch at 34020 RPM: 4.5 × 0.0254 m/rev × 567 rev/s × 3.6
+  assertAlmostEquals(pitchSpeedKmh(4.5, 34020), 4.5 * 0.0254 * 567 * 3.6, 1e-6);
+});
+
+// ---------------------------------------------------------------------------
+// Static thrust
+// ---------------------------------------------------------------------------
+
+Deno.test("staticThrustGrams - 5-inch freestyle setup lands in plausible range", () => {
+  // 5x4.5 tri-blade at ~34k loaded RPM (2207 1800KV on 6S): real-world
+  // thrust-stand numbers for this class are roughly 1.2-1.9 kg per motor.
+  const t = staticThrustGrams(5, 4.5, 34020, 3);
+  assert(t > 1100 && t < 1900, `thrust ${t}g outside plausible range`);
+});
+
+Deno.test("staticThrustGrams - scales with RPM squared", () => {
+  const low = staticThrustGrams(5, 4.5, 20000, 2);
+  const high = staticThrustGrams(5, 4.5, 40000, 2);
+  assertAlmostEquals(high / low, 4, 1e-9);
+});
+
+Deno.test("staticThrustGrams - more blades produce more thrust at same RPM", () => {
+  const two = staticThrustGrams(5, 4.5, 30000, 2);
+  const three = staticThrustGrams(5, 4.5, 30000, 3);
+  const four = staticThrustGrams(5, 4.5, 30000, 4);
+  assert(three > two);
+  assert(four > three);
+  // Diminishing returns: each extra blade adds less than the previous one
+  assert(four - three < three - two);
+});
+
+// ---------------------------------------------------------------------------
+// Weight-relative metrics
+// ---------------------------------------------------------------------------
+
+Deno.test("thrustToWeight - simple ratio", () => {
+  assertEquals(thrustToWeight(6000, 600), 10);
+});
+
+Deno.test("hoverThrottlePercent - thrust proportional to throttle squared", () => {
+  // TWR 9 → hover at 1/9 max thrust → sqrt(1/9) = 33.3% throttle
+  assertAlmostEquals(hoverThrottlePercent(9), 100 / 3, 0.01);
+});
+
+Deno.test("discLoading - grams per cm² of disc area", () => {
+  // 650g on four 5" discs: 650 / (4 × π × 6.35²)
+  assertAlmostEquals(discLoading(650, 5, 4), 650 / (4 * Math.PI * 6.35 * 6.35), 1e-6);
+});
+
+// ---------------------------------------------------------------------------
+// Recommendations - KV / cells
+// ---------------------------------------------------------------------------
+
+Deno.test("recommendKv - 5-inch on 6S centers near 1800", () => {
+  const r = recommendKv(5, 25.2, "freestyle");
+  assert(r.ideal > 1600 && r.ideal < 2000, `ideal ${r.ideal}`);
+  assert(r.min < 1800 && r.max > 1800);
+});
+
+Deno.test("recommendKv - 5-inch on 4S centers near 2600", () => {
+  const r = recommendKv(5, 16.8, "freestyle");
+  assert(r.ideal > 2400 && r.ideal < 2900, `ideal ${r.ideal}`);
+});
+
+Deno.test("recommendKv - 7-inch on 6S centers near 1300-1500", () => {
+  const r = recommendKv(7, 25.2, "freestyle");
+  assert(r.ideal > 1200 && r.ideal < 1550, `ideal ${r.ideal}`);
+});
+
+Deno.test("recommendKv - tiny whoop on 1S lands in the tens of thousands", () => {
+  const r = recommendKv(1.2, 4.2, "freestyle");
+  assert(r.ideal > 19000 && r.ideal < 28000, `ideal ${r.ideal}`);
+});
+
+Deno.test("recommendCellCount - 5-inch 1800KV wants 6S", () => {
+  assertEquals(recommendCellCount(5, 1800, "freestyle").ideal, 6);
+});
+
+Deno.test("recommendCellCount - 5-inch 2600KV wants 4S", () => {
+  assertEquals(recommendCellCount(5, 2600, "freestyle").ideal, 4);
+});
+
+Deno.test("recommendCellCount - 7-inch 1300KV wants 6S", () => {
+  assertEquals(recommendCellCount(7, 1300, "freestyle").ideal, 6);
+});
+
+// ---------------------------------------------------------------------------
+// Recommendations - motor size / prop / pitch / AUW
+// ---------------------------------------------------------------------------
+
+Deno.test("recommendMotorSizes - 5-inch includes the classic 22xx/23xx stators", () => {
+  const { sizes } = recommendMotorSizes(5);
+  assert(sizes.includes("2207"), `got ${sizes}`);
+  assert(sizes.includes("2306"), `got ${sizes}`);
+  assert(!sizes.includes("1404"));
+  assert(!sizes.includes("0802"));
+});
+
+Deno.test("recommendMotorSizes - 3-inch includes 14xx stators", () => {
+  const { sizes } = recommendMotorSizes(3);
+  assert(sizes.includes("1404"), `got ${sizes}`);
+  assert(!sizes.includes("2207"));
+});
+
+Deno.test("recommendMotorSizes - tiny whoop includes 0802", () => {
+  const { sizes } = recommendMotorSizes(1.2);
+  assert(sizes.includes("0802"), `got ${sizes}`);
+});
+
+Deno.test("recommendPropDiameter - 2207 centers on the 5-inch class", () => {
+  const r = recommendPropDiameter("2207");
+  assert(r.min < 5 && r.max > 5, `range ${r.min}-${r.max}`);
+  assert(r.min > 3.5 && r.max < 7.5, `range ${r.min}-${r.max}`);
+});
+
+Deno.test("recommendPropDiameter - invalid motor size returns null", () => {
+  assertEquals(recommendPropDiameter("nope"), null);
+});
+
+Deno.test("recommendPitch - freestyle 5-inch covers common 4.3-4.5 pitches", () => {
+  const r = recommendPitch(5, "freestyle");
+  assert(r.min <= 4.3 && r.max >= 4.5, `range ${r.min}-${r.max}`);
+});
+
+Deno.test("recommendPitch - cinematic runs lower pitch than racing", () => {
+  const cine = recommendPitch(5, "cinematic");
+  const race = recommendPitch(5, "racing");
+  assert(cine.max < race.max);
+});
+
+Deno.test("recommendAuw - freestyle band around a 5-inch 6S build includes 650g", () => {
+  // ~6kg total static thrust is typical for 2207 1800KV 6S on 5x4.5x3
+  const r = recommendAuw(6000, "freestyle");
+  assert(r.min < 650 && r.max > 650, `range ${r.min}-${r.max}`);
+});
+
+// ---------------------------------------------------------------------------
+// analyze() orchestration
+// ---------------------------------------------------------------------------
+
+const FULL_5IN_6S = {
+  diameterIn: 5,
+  pitchIn: 4.5,
+  blades: 3,
+  motorSize: "2207",
+  kv: 1800,
+  cells: 6,
+  auwGrams: 650,
+  motorCount: 4,
+  style: "freestyle",
+};
+
+Deno.test("analyze - full 5-inch 6S freestyle build produces sane metrics", () => {
+  const { metrics, recommendations, verdicts } = analyze(FULL_5IN_6S);
+  assertAlmostEquals(metrics.voltage, 25.2, 1e-9);
+  assertAlmostEquals(metrics.loadedRpm, 34020, 1e-6);
+  assert(metrics.totalThrustG > 4800 && metrics.totalThrustG < 7600);
+  assert(metrics.twr > 7 && metrics.twr < 12, `twr ${metrics.twr}`);
+  assert(metrics.hoverThrottlePct > 25 && metrics.hoverThrottlePct < 40);
+  assert(metrics.tipMach > 0.5 && metrics.tipMach < 0.8);
+  assert(metrics.maxCurrentA > 15 && metrics.maxCurrentA < 45);
+  // Everything was specified, so nothing to recommend
+  assertEquals(Object.keys(recommendations).length, 0);
+  assert(verdicts.length > 0);
+  assert(verdicts.some((v: { level: string }) => v.level === "good"));
+});
+
+Deno.test("analyze - sparse inputs yield recommendations instead of metrics", () => {
+  const { metrics, recommendations } = analyze({
+    diameterIn: 5,
+    cells: 6,
+    blades: 3,
+    motorCount: 4,
+    style: "freestyle",
+  });
+  assert(recommendations.kv, "expected a KV recommendation");
+  assert(recommendations.kv.ideal > 1600 && recommendations.kv.ideal < 2000);
+  assert(recommendations.motorSizes.sizes.includes("2306"));
+  assert(recommendations.pitch, "expected a pitch recommendation");
+  assertEquals(metrics.twr, undefined);
+});
+
+Deno.test("analyze - unparseable motor size is treated as unset", () => {
+  const { recommendations } = analyze({
+    diameterIn: 5,
+    motorSize: "abc",
+    blades: 3,
+    motorCount: 4,
+    style: "freestyle",
+  });
+  assert(recommendations.motorSizes, "expected motor size recommendation");
+});
+
+Deno.test("analyze - grossly overloaded build gets a 'bad' verdict", () => {
+  const { verdicts } = analyze({ ...FULL_5IN_6S, auwGrams: 8000 });
+  assert(verdicts.some((v: { level: string }) => v.level === "bad"));
+});
+
+Deno.test("analyze - empty input does not throw", () => {
+  const { metrics, recommendations, verdicts } = analyze({});
+  assertEquals(Object.keys(metrics).length, 0);
+  assertEquals(Object.keys(recommendations).length, 0);
+  assertEquals(verdicts.length, 0);
+});

--- a/tests/site.test.ts
+++ b/tests/site.test.ts
@@ -20,6 +20,7 @@ const PAGES = [
   { path: "cli-merge/index.html", root: "../", home: false },
   { path: "rate-profile/index.html", root: "../", home: false },
   { path: "igow/index.html", root: "../", home: false },
+  { path: "prop-motor-sizer/index.html", root: "../", home: false },
 ];
 
 for (const page of PAGES) {


### PR DESCRIPTION
## Summary

- New `prop-motor-sizer/` tool: enter prop diameter/pitch/blades, motor stator size, KV, battery cells, and AUW to characterize a powertrain — or leave any subset blank to get suggested ranges derived from what you did enter
- Flight-character verdicts: thrust-to-weight interpretation, motor/prop torque match (stator volume vs. prop diameter), KV-vs-voltage rev match, tip-speed (Mach) warnings, hover-headroom warning
- Estimated numbers: static thrust (Staples model + blade-count factor), hover throttle, RPM under load, tip speed, pitch speed, hover and full-throttle current draw (momentum theory), disc loading
- Reverse sizing: 5″ prop on 6S suggests a KV band and suitable stator sizes; a motor size suggests the prop diameters it suits; a complete powertrain suggests an AUW band for the chosen flying style
- Flying-style setting (cinematic / long-range / freestyle / racing) biases pitch, KV, and AUW recommendations; presets for tiny whoop, 3″ 4S, 5″ 6S freestyle, 5″ 4S race, and 7″ long-range
- Advanced panel (collapsed by default): motor load factor, battery chemistry (LiPo/LiHV/Li-Ion) with voltage basis (full charge / nominal / under load), altitude-based air-density derating, battery capacity for a hover-endurance estimate, and a thrust-stand calibration field that rescales the model to one measured data point (KV/cell recommendations stay on the full-charge convention regardless of basis)
- Pure calculation module (`src/sizer-calculator.js`) with 48 unit tests; page covered by the shared-header site tests; wired into the hub, README, and service-worker precache (cache bumped to v2)
- Inputs persist in localStorage; estimates are labeled as ±20–30% ballparks unless calibrated

## Test plan

- [x] `deno task test` — 153 passed, 0 failed
- [x] `deno fmt --check tests/` clean (matches CI)
- [x] Browser smoke test: empty state renders; 5″ 6S preset produces sane metrics and verdicts; clearing KV/motor size surfaces recommended ranges; no console errors
- [x] Advanced panel in-browser: capacity adds an endurance card, 2000 m altitude derates thrust ~18% and shows the density card, calibration adds its verdict, load-factor slider and voltage basis update RPM/current, Clear all restores defaults
- [x] Mobile (390px) layout stacks correctly
- [x] Hub card links to the new tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZNCRL7V2qNBZNSrNdP4PR